### PR TITLE
Initial working version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,23 @@
+target/
+!.mvn/wrapper/maven-wrapper.jar
+
+### STS ###
+.classpath
+.factorypath
+.project
+.settings
+.springBeans
+
+### IntelliJ IDEA ###
+.idea
+*.iws
+*.iml
+*.ipr
+
+### NetBeans ###
+nbproject/private/
+build/
+nbbuild/
+dist/
+nbdist/
+.nb-gradle/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+language: java
+jdk:
+  - oraclejdk8
+install: mvn install -DskipTests=true -Dcobertura.skip=true -Dmaven.javadoc.skip=true -B -V
+script: mvn clean verify

--- a/README.md
+++ b/README.md
@@ -119,6 +119,25 @@ INFO 57755 --- [pool-2-thread-1] c.s.c.core.sender.BufferedMetricsSender  : Dry 
 INFO 57755 --- [pool-2-thread-1] c.s.c.core.sender.BufferedMetricsSender  : Dry metric: example.springboot.gauge.system.heap,framework=springboot,application=starter,type=used 112536.0 1476909489668
 ```
 
+### Control Processors
+
+You can enable/disable all metric processors by setting the following properties:
+ 
+```
+statful.client.springboot.processors.tomcat.httpSessions.enabled=true
+statful.client.springboot.processors.http.httpRequests.enabled=true
+statful.client.springboot.processors.system.classes.enabled=true
+statful.client.springboot.processors.system.gc.enabled=true
+statful.client.springboot.processors.system.heap.enabled=true
+statful.client.springboot.processors.system.mem.enabled=true
+statful.client.springboot.processors.system.processors.enabled=true
+statful.client.springboot.processors.system.systemload.enabled=true
+statful.client.springboot.processors.system.threads.enabled=true
+statful.client.springboot.processors.system.uptime.enabled=true
+```
+
+All processors are enabled by default.
+
 ## Reference
 
 ### Collected Metrics

--- a/README.md
+++ b/README.md
@@ -1,0 +1,152 @@
+Statful Client for Java
+==============
+
+[![Build Status](https://travis-ci.org/statful/statful-client-springboot.svg?branch=master)](https://travis-ci.org/statful/statful-client-springboot)
+
+Statful client for Springboot. This client is intended to gather metrics provided by [springboot-actuator](http://docs.spring.io/spring-boot/docs/current/reference/html/production-ready-metrics.html) and send them to Statful.
+
+> At this point only system, tomcat and http metrics are collected but support for datasource and cache metrics will be added soon.
+
+## Table of Contents
+
+* [Supported Versions of Java](#supported-versions-of-java)
+* [Requirements](#requirements)
+* [Quick Start](#quick-start)
+* [Examples](#examples)
+* [Reference](#reference)
+* [Authors](#authors)
+* [License](#license)
+
+## Supported Versions of Java
+
+| Statful client version | Tested Java versions  | Tested Spring Boot versions
+|:---|:---:---|
+| 1.x.x | `Java 8` | `1.4.1.RELEASE` |
+
+## Requirements
+
+This client has the following requirements:
+
+* [springboot-actuator](https://github.com/spring-projects/spring-boot/tree/master/spring-boot-actuator) in order to collect system, datasource, http, etc. metrics.
+* [statful-client-java](https://github.com/statful/statful-client-java) in order to send metrics into Statful.
+
+## Quick start
+
+This client requires you to configure and initialize a `StatfulClient` bean as described [here](https://github.com/statful/statful-client-java#quick-start).  
+
+After that simply add the dependency using Maven for example:
+
+```
+<dependency>
+    <groupId>com.statful.client.framework</groupId>
+    <artifactId>client-springboot</artifactId>
+    <version>${statful-client-springboot.version}</version>
+</dependency>
+```
+
+And enable metric collection by setting the following property:
+
+```
+statful.client.springboot.metrics.enabled=true
+```
+
+> **IMPORTANT:** This client partially uses the `StatfulClient` configuration. Although it doesn't reuse the global tags, aggregations or namespaces. Those can be set via application properties as described below.
+
+## Examples
+
+You can see the metrics output by running the client in dry-run mode, it will look similar to:
+
+```
+INFO 57428 --- [pool-2-thread-1] c.s.c.core.sender.BufferedMetricsSender  : Dry metric: springboot.gauge.system.mem,type=total 535284.0 1476908774549
+INFO 57428 --- [pool-2-thread-1] c.s.c.core.sender.BufferedMetricsSender  : Dry metric: springboot.gauge.system.mem,type=free 436612.0 1476908774549
+INFO 57428 --- [pool-2-thread-1] c.s.c.core.sender.BufferedMetricsSender  : Dry metric: springboot.gauge.system.processors 8.0 1476908774549
+INFO 57428 --- [pool-2-thread-1] c.s.c.core.sender.BufferedMetricsSender  : Dry metric: springboot.gauge.system.uptime,type=instance 47148.0 1476908774549
+INFO 57428 --- [pool-2-thread-1] c.s.c.core.sender.BufferedMetricsSender  : Dry metric: springboot.gauge.system.uptime,type=vm 53309.0 1476908774549
+INFO 57428 --- [pool-2-thread-1] c.s.c.core.sender.BufferedMetricsSender  : Dry metric: springboot.gauge.system.systemload 4.0888671875 1476908774549 Aggregation: AVG Frequency: FREQ_60
+INFO 57428 --- [pool-2-thread-1] c.s.c.core.sender.BufferedMetricsSender  : Dry metric: springboot.gauge.system.heap,type=committed 479744.0 1476908774549
+INFO 57428 --- [pool-2-thread-1] c.s.c.core.sender.BufferedMetricsSender  : Dry metric: springboot.gauge.system.heap,type=init 262144.0 1476908774549
+INFO 57428 --- [pool-2-thread-1] c.s.c.core.sender.BufferedMetricsSender  : Dry metric: springboot.gauge.system.heap,type=used 43131.0 1476908774549
+INFO 57428 --- [pool-2-thread-1] c.s.c.core.sender.BufferedMetricsSender  : Dry metric: springboot.gauge.system.heap,type=max 3728384.0 1476908774549
+INFO 57428 --- [pool-2-thread-1] c.s.c.core.sender.BufferedMetricsSender  : Dry metric: springboot.gauge.system.nonheap,type=committed 57344.0 1476908774549
+INFO 57428 --- [pool-2-thread-1] c.s.c.core.sender.BufferedMetricsSender  : Dry metric: springboot.gauge.system.nonheap,type=init 2496.0 1476908774549
+INFO 57428 --- [pool-2-thread-1] c.s.c.core.sender.BufferedMetricsSender  : Dry metric: springboot.gauge.system.nonheap,type=used 55540.0 1476908774549
+INFO 57428 --- [pool-2-thread-1] c.s.c.core.sender.BufferedMetricsSender  : Dry metric: springboot.gauge.system.nonheap,type=max 0.0 1476908774549
+INFO 57428 --- [pool-2-thread-1] c.s.c.core.sender.BufferedMetricsSender  : Dry metric: springboot.gauge.system.threads,type=peak 22.0 1476908774549
+INFO 57428 --- [pool-2-thread-1] c.s.c.core.sender.BufferedMetricsSender  : Dry metric: springboot.gauge.system.threads,type=daemon 19.0 1476908774549
+INFO 57428 --- [pool-2-thread-1] c.s.c.core.sender.BufferedMetricsSender  : Dry metric: springboot.gauge.system.threads,type=totalStarted 26.0 1476908774549
+INFO 57428 --- [pool-2-thread-1] c.s.c.core.sender.BufferedMetricsSender  : Dry metric: springboot.gauge.system.threads,type=total 22.0 1476908774549
+INFO 57428 --- [pool-2-thread-1] c.s.c.core.sender.BufferedMetricsSender  : Dry metric: springboot.gauge.system.classes,type=total 6614.0 1476908774549
+INFO 57428 --- [pool-2-thread-1] c.s.c.core.sender.BufferedMetricsSender  : Dry metric: springboot.gauge.system.classes,type=loaded 6615.0 1476908774549
+INFO 57428 --- [pool-2-thread-1] c.s.c.core.sender.BufferedMetricsSender  : Dry metric: springboot.gauge.system.classes,type=unloaded 1.0 1476908774549
+INFO 57428 --- [pool-2-thread-1] c.s.c.core.sender.BufferedMetricsSender  : Dry metric: springboot.counter.system.accumulated.gc,name=ps_scavenge 8.0 1476908774549
+INFO 57428 --- [pool-2-thread-1] c.s.c.core.sender.BufferedMetricsSender  : Dry metric: springboot.timer.system.accumulated.gc,name=ps_scavenge 97.0 1476908774549
+INFO 57428 --- [pool-2-thread-1] c.s.c.core.sender.BufferedMetricsSender  : Dry metric: springboot.counter.system.accumulated.gc,name=ps_marksweep 2.0 1476908774549
+INFO 57428 --- [pool-2-thread-1] c.s.c.core.sender.BufferedMetricsSender  : Dry metric: springboot.timer.system.accumulated.gc,name=ps_marksweep 141.0 1476908774549
+INFO 57428 --- [pool-2-thread-1] c.s.c.core.sender.BufferedMetricsSender  : Dry metric: springboot.gauge.tomcat.httpsessions,type=max -1.0 1476908774549
+INFO 57428 --- [pool-2-thread-1] c.s.c.core.sender.BufferedMetricsSender  : Dry metric: springboot.gauge.tomcat.httpsessions,type=active 0.0 1476908774549
+INFO 57428 --- [pool-2-thread-1] c.s.c.core.sender.BufferedMetricsSender  : Dry metric: springboot.timer.latest.responses,url=metrics 4.0 1476908774549
+INFO 57428 --- [pool-2-thread-1] c.s.c.core.sender.BufferedMetricsSender  : Dry metric: springboot.timer.latest.responses,url=star-star.favicon.ico 7.0 1476908774549
+INFO 57428 --- [pool-2-thread-1] c.s.c.core.sender.BufferedMetricsSender  : Dry metric: springboot.counter.accumulated.requests,url=star-star.favicon.ico,status=200 6.0 1476908774549
+INFO 57428 --- [pool-2-thread-1] c.s.c.core.sender.BufferedMetricsSender  : Dry metric: springboot.counter.accumulated.requests,url=metrics,status=200 5.0 1476908774549
+```
+
+### Extra Configuration
+
+You can get an extra level of customization by setting the namespace, prefix and a list of tags to be added across all collected metrics.
+
+For that set the following application properties:
+
+```
+statful.client.springboot.metrics.namespace=example
+statful.client.springboot.metrics.prefix=springboot
+statful.client.springboot.metrics.tags[0].name=application
+statful.client.springboot.metrics.tags[0].value=starter
+statful.client.springboot.metrics.tags[1].name=framework
+statful.client.springboot.metrics.tags[1].value=springboot
+```
+
+An example of the output this configuration would generate is:
+
+```
+INFO 57755 --- [pool-2-thread-1] c.s.c.core.sender.BufferedMetricsSender  : Dry metric: example.springboot.gauge.system.mem,framework=springboot,application=starter,type=total 439643.0 1476909489668
+INFO 57755 --- [pool-2-thread-1] c.s.c.core.sender.BufferedMetricsSender  : Dry metric: example.springboot.gauge.system.mem,framework=springboot,application=starter,type=free 272999.0 1476909489668
+INFO 57755 --- [pool-2-thread-1] c.s.c.core.sender.BufferedMetricsSender  : Dry metric: example.springboot.gauge.system.processors,application=starter,framework=springboot 8.0 1476909489668
+INFO 57755 --- [pool-2-thread-1] c.s.c.core.sender.BufferedMetricsSender  : Dry metric: example.springboot.gauge.system.uptime,framework=springboot,application=starter,type=instance 26554.01476909489668
+INFO 57755 --- [pool-2-thread-1] c.s.c.core.sender.BufferedMetricsSender  : Dry metric: example.springboot.gauge.system.uptime,framework=springboot,application=starter,type=vm 31126.0 1476909489668
+INFO 57755 --- [pool-2-thread-1] c.s.c.core.sender.BufferedMetricsSender  : Dry metric: example.springboot.gauge.system.systemload,application=starter,framework=springboot 3.005859375 1476909489668 Aggregation: AVG Frequency: FREQ_60
+INFO 57755 --- [pool-2-thread-1] c.s.c.core.sender.BufferedMetricsSender  : Dry metric: example.springboot.gauge.system.heap,framework=springboot,application=starter,type=committed 385536.0 1476909489668
+INFO 57755 --- [pool-2-thread-1] c.s.c.core.sender.BufferedMetricsSender  : Dry metric: example.springboot.gauge.system.heap,framework=springboot,application=starter,type=init 262144.0 1476909489668
+INFO 57755 --- [pool-2-thread-1] c.s.c.core.sender.BufferedMetricsSender  : Dry metric: example.springboot.gauge.system.heap,framework=springboot,application=starter,type=used 112536.0 1476909489668
+```
+
+Optional unit tags can also be enabled by setting the following application property:
+
+```
+statful.client.springboot.metrics.units.enabled=true
+```
+
+This is highly recommended as it will add important context to the metrics when exploring the data.
+
+## Reference
+
+### Collected Metrics
+
+Metrics are collected according to what's described in the [Spring Boot documentation](http://docs.spring.io/spring-boot/docs/current/reference/html/production-ready-metrics.html) and modelled into Statful format with the following considerations:
+
+* The type of metric is inferred by the metric's meaning with is decided both from the Spring Boot documentation and the actual code that exports data
+* The majority of metrics are `gauges` and represent a particular value collected in an instant
+* Times such as `gc` collection time or `http` response time are modelled as a `timers`
+* Counts such as `gc` collection count or `http` request count are modelled as `counters`
+* Some metrics represent an accumulated value over time, these are prefixed with `accumulated` on the metric name
+* Some metrics represent the last measured value for a particular entry, these are prefixed with `latest` on the metric name
+* Metrics that represent a value aggregated over a period of time are sent to Statful as previously aggregated
+ 
+> Note that aggregated metrics are currently only supported by using the HTTP transport on the `StatfulClient`.
+
+## Authors
+
+[Mindera - Software Craft](https://github.com/Mindera)
+
+## License
+
+Statful Spring Boot Client is available under the MIT license. See the [LICENSE](https://raw.githubusercontent.com/statful/statful-client-springboot/master/LICENSE) file for more information.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Statful client for Springboot. This client is intended to gather metrics provide
 ## Supported Versions of Java
 
 | Statful client version | Tested Java versions  | Tested Spring Boot versions
-|:---|:---:---|
+|:---|:---|:---|
 | 1.x.x | `Java 8` | `1.4.1.RELEASE` |
 
 ## Requirements
@@ -118,14 +118,6 @@ INFO 57755 --- [pool-2-thread-1] c.s.c.core.sender.BufferedMetricsSender  : Dry 
 INFO 57755 --- [pool-2-thread-1] c.s.c.core.sender.BufferedMetricsSender  : Dry metric: example.springboot.gauge.system.heap,framework=springboot,application=starter,type=init 262144.0 1476909489668
 INFO 57755 --- [pool-2-thread-1] c.s.c.core.sender.BufferedMetricsSender  : Dry metric: example.springboot.gauge.system.heap,framework=springboot,application=starter,type=used 112536.0 1476909489668
 ```
-
-Optional unit tags can also be enabled by setting the following application property:
-
-```
-statful.client.springboot.metrics.units.enabled=true
-```
-
-This is highly recommended as it will add important context to the metrics when exploring the data.
 
 ## Reference
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.statful.client.framework</groupId>
     <artifactId>client-springboot</artifactId>
-    <version>0.0.1-SNAPSHOT</version>
+    <version>1.0.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>spring-client-springboot</name>

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <java.version>1.8</java.version>
-        <statful-client.version>1.1.1-SNAPSHOT</statful-client.version>
+        <statful-client.version>1.2.0</statful-client.version>
         <spring-boot-actuator.version>1.4.1.RELEASE</spring-boot-actuator.version>
         <spring-boot-configuration-processor.version>1.4.1.RELEASE</spring-boot-configuration-processor.version>
         <mockito.version>1.10.19</mockito.version>

--- a/pom.xml
+++ b/pom.xml
@@ -18,6 +18,8 @@
         <statful-client.version>1.1.1-SNAPSHOT</statful-client.version>
         <spring-boot-actuator.version>1.4.1.RELEASE</spring-boot-actuator.version>
         <spring-boot-configuration-processor.version>1.4.1.RELEASE</spring-boot-configuration-processor.version>
+        <mockito.version>1.10.19</mockito.version>
+        <junit.version>4.12</junit.version>
     </properties>
 
     <dependencies>
@@ -48,6 +50,20 @@
             <version>${spring-boot-configuration-processor.version}</version>
             <optional>true</optional>
         </dependency>
+
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-all</artifactId>
+            <version>${mockito.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>${junit.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>
@@ -64,6 +80,27 @@
                     <source>1.8</source>
                     <target>1.8</target>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>cobertura-maven-plugin</artifactId>
+                <version>2.7</version>
+                <configuration>
+                    <aggregate>true</aggregate>
+                    <check>
+                        <haltOnFailure>true</haltOnFailure>
+                        <totalBranchRate>95</totalBranchRate>
+                        <totalLineRate>95</totalLineRate>
+                    </check>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>clean</goal>
+                            <goal>check</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.statful.client.framework</groupId>
+    <artifactId>client-springboot</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <packaging>jar</packaging>
+
+    <name>spring-client-springboot</name>
+    <description>Spring Boot client to send metrics to Statful.</description>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <java.version>1.8</java.version>
+        <statful-client.version>1.1.1-SNAPSHOT</statful-client.version>
+        <spring-boot-actuator.version>1.4.1.RELEASE</spring-boot-actuator.version>
+        <spring-boot-configuration-processor.version>1.4.1.RELEASE</spring-boot-configuration-processor.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.statful.client</groupId>
+            <artifactId>http-client</artifactId>
+            <version>${statful-client.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.statful.client</groupId>
+            <artifactId>udp-client</artifactId>
+            <version>${statful-client.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-actuator</artifactId>
+            <version>${spring-boot-actuator.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-configuration-processor</artifactId>
+            <version>${spring-boot-configuration-processor.version}</version>
+            <optional>true</optional>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.3</version>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/main/java/com/statful/client/framework/springboot/common/AggregationDetails.java
+++ b/src/main/java/com/statful/client/framework/springboot/common/AggregationDetails.java
@@ -1,0 +1,22 @@
+package com.statful.client.framework.springboot.common;
+
+import com.statful.client.domain.api.Aggregation;
+import com.statful.client.domain.api.AggregationFreq;
+
+public class AggregationDetails {
+    private Aggregation aggregation;
+    private AggregationFreq aggregationFreq;
+
+    public AggregationDetails(Aggregation aggregation, AggregationFreq aggregationFreq) {
+        this.aggregation = aggregation;
+        this.aggregationFreq = aggregationFreq;
+    }
+
+    public Aggregation getAggregation() {
+        return aggregation;
+    }
+
+    public AggregationFreq getAggregationFreq() {
+        return aggregationFreq;
+    }
+}

--- a/src/main/java/com/statful/client/framework/springboot/common/AggregationDetails.java
+++ b/src/main/java/com/statful/client/framework/springboot/common/AggregationDetails.java
@@ -3,10 +3,18 @@ package com.statful.client.framework.springboot.common;
 import com.statful.client.domain.api.Aggregation;
 import com.statful.client.domain.api.AggregationFrequency;
 
+/**
+ * Holder class to represent and aggregation and an aggregation frequency.
+ */
 public class AggregationDetails {
     private Aggregation aggregation;
     private AggregationFrequency aggregationFreq;
 
+    /**
+     * Default constructor
+     * @param aggregation An {@link Aggregation} aggregation
+     * @param aggregationFreq An {@link AggregationFrequency} aggregation frequency
+     */
     public AggregationDetails(Aggregation aggregation, AggregationFrequency aggregationFreq) {
         this.aggregation = aggregation;
         this.aggregationFreq = aggregationFreq;

--- a/src/main/java/com/statful/client/framework/springboot/common/AggregationDetails.java
+++ b/src/main/java/com/statful/client/framework/springboot/common/AggregationDetails.java
@@ -1,13 +1,13 @@
 package com.statful.client.framework.springboot.common;
 
 import com.statful.client.domain.api.Aggregation;
-import com.statful.client.domain.api.AggregationFreq;
+import com.statful.client.domain.api.AggregationFrequency;
 
 public class AggregationDetails {
     private Aggregation aggregation;
-    private AggregationFreq aggregationFreq;
+    private AggregationFrequency aggregationFreq;
 
-    public AggregationDetails(Aggregation aggregation, AggregationFreq aggregationFreq) {
+    public AggregationDetails(Aggregation aggregation, AggregationFrequency aggregationFreq) {
         this.aggregation = aggregation;
         this.aggregationFreq = aggregationFreq;
     }
@@ -16,7 +16,7 @@ public class AggregationDetails {
         return aggregation;
     }
 
-    public AggregationFreq getAggregationFreq() {
+    public AggregationFrequency getAggregationFrequency() {
         return aggregationFreq;
     }
 }

--- a/src/main/java/com/statful/client/framework/springboot/common/ExportedMetric.java
+++ b/src/main/java/com/statful/client/framework/springboot/common/ExportedMetric.java
@@ -3,11 +3,18 @@ package com.statful.client.framework.springboot.common;
 import java.util.Date;
 import java.util.Objects;
 
+/**
+ * Class to represent a metric exported by Actuator.
+ */
 public class ExportedMetric {
     private String name;
     private Number value;
     private Date timestamp;
 
+    /**
+     * Builder constructor.
+     * @param builder {@link com.statful.client.framework.springboot.common.ExportedMetric.Builder}
+     */
     public ExportedMetric(Builder builder) {
         this.name = builder.name;
         this.value = builder.value;

--- a/src/main/java/com/statful/client/framework/springboot/common/ExportedMetric.java
+++ b/src/main/java/com/statful/client/framework/springboot/common/ExportedMetric.java
@@ -1,0 +1,55 @@
+package com.statful.client.framework.springboot.common;
+
+import java.util.Date;
+import java.util.Objects;
+
+public class ExportedMetric {
+    private String name;
+    private Number value;
+    private Date timestamp;
+
+    public ExportedMetric(Builder builder) {
+        this.name = builder.name;
+        this.value = builder.value;
+        this.timestamp = builder.timestamp;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public Number getValue() {
+        return value;
+    }
+
+    public Date getTimestamp() {
+        return timestamp;
+    }
+
+    public static final class Builder {
+
+        private String name;
+        private Number value;
+        private Date timestamp;
+
+        public Builder withName(String name) {
+            this.name = Objects.requireNonNull(name, "Metric name cannot be null");
+            return this;
+        }
+
+        public Builder withValue(Number value) {
+            this.value = Objects.requireNonNull(value, "Value cannot be null");
+            return this;
+        }
+
+        public Builder withTimestamp(Date timestamp) {
+            this.timestamp = Objects.requireNonNull(timestamp, "Timestamp cannot be null");
+            return this;
+        }
+
+        public ExportedMetric build() {
+            return new ExportedMetric(this);
+        }
+
+    }
+}

--- a/src/main/java/com/statful/client/framework/springboot/common/MetricType.java
+++ b/src/main/java/com/statful/client/framework/springboot/common/MetricType.java
@@ -1,0 +1,7 @@
+package com.statful.client.framework.springboot.common;
+
+public enum MetricType {
+    COUNTER,
+    TIMER,
+    GAUGE
+}

--- a/src/main/java/com/statful/client/framework/springboot/common/MetricType.java
+++ b/src/main/java/com/statful/client/framework/springboot/common/MetricType.java
@@ -1,5 +1,8 @@
 package com.statful.client.framework.springboot.common;
 
+/**
+ * Enum representing the available metric types.
+ */
 public enum MetricType {
     COUNTER,
     TIMER,

--- a/src/main/java/com/statful/client/framework/springboot/common/ProcessedMetric.java
+++ b/src/main/java/com/statful/client/framework/springboot/common/ProcessedMetric.java
@@ -6,6 +6,9 @@ import com.statful.client.domain.api.Tags;
 import java.util.Objects;
 import java.util.Optional;
 
+/**
+ * Class representing a metric processed by the Statful processors.
+ */
 public class ProcessedMetric {
 
     private String name;
@@ -16,6 +19,10 @@ public class ProcessedMetric {
     private Aggregations aggregations;
     private AggregationDetails aggregationDetails;
 
+    /**
+     * Builder constructor.
+     * @param builder {@link com.statful.client.framework.springboot.common.ProcessedMetric.Builder}
+     */
     public ProcessedMetric(Builder builder) {
         this.name = builder.name;
         this.metricType = builder.metricType;

--- a/src/main/java/com/statful/client/framework/springboot/common/ProcessedMetric.java
+++ b/src/main/java/com/statful/client/framework/springboot/common/ProcessedMetric.java
@@ -1,0 +1,109 @@
+package com.statful.client.framework.springboot.common;
+
+import com.statful.client.domain.api.Aggregation;
+import com.statful.client.domain.api.AggregationFreq;
+import com.statful.client.domain.api.Aggregations;
+import com.statful.client.domain.api.Tags;
+
+import java.util.Objects;
+import java.util.Optional;
+
+public class ProcessedMetric {
+
+    private String name;
+    private MetricType metricType;
+    private Tags tags;
+    private Double value;
+    private long timestamp;
+    private Aggregations aggregations;
+    private AggregationDetails aggregationDetails;
+
+    public ProcessedMetric(Builder builder) {
+        this.name = builder.name;
+        this.metricType = builder.metricType;
+        this.tags = builder.tags;
+        this.value = builder.value;
+        this.timestamp = builder.timestamp;
+        this.aggregations = builder.aggregations;
+        this.aggregationDetails = builder.aggregationDetails;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public MetricType getMetricType() {
+        return metricType;
+    }
+
+    public Optional<Tags> getTags() {
+        return Optional.ofNullable(tags);
+    }
+
+    public Double getValue() {
+        return value;
+    }
+
+    public long getTimestamp() {
+        return timestamp;
+    }
+
+    public Optional<Aggregations> getAggregations() {
+        return Optional.ofNullable(aggregations);
+    }
+
+    public Optional<AggregationDetails> getAggregationDetails() {
+        return Optional.ofNullable(aggregationDetails);
+    }
+
+    public static final class Builder {
+
+        private String name;
+        private MetricType metricType;
+        private Tags tags;
+        private Double value;
+        private long timestamp;
+        private Aggregations aggregations;
+        private AggregationDetails aggregationDetails;
+
+        public Builder withName(String name) {
+            this.name = Objects.requireNonNull(name, "Metric name cannot be null");
+            return this;
+        }
+
+        public Builder withMetricType(MetricType metricType) {
+            this.metricType = metricType;
+            return this;
+        }
+
+        public Builder withTags(Tags tags) {
+            this.tags = tags;
+            return this;
+        }
+
+        public Builder withValue(Double value) {
+            this.value = Objects.requireNonNull(value, "Value cannot be null");
+            return this;
+        }
+
+        public Builder withTimestamp(long timestamp) {
+            this.timestamp = Objects.requireNonNull(timestamp, "Timestamp cannot be null");
+            return this;
+        }
+
+        public Builder withAggregations(Aggregations aggregations) {
+            this.aggregations = aggregations;
+            return this;
+        }
+
+        public Builder aggregatedBy(AggregationDetails aggregationDetails) {
+            this.aggregationDetails = aggregationDetails;
+            return this;
+        }
+
+        public ProcessedMetric build() {
+            return new ProcessedMetric(this);
+        }
+
+    }
+}

--- a/src/main/java/com/statful/client/framework/springboot/common/ProcessedMetric.java
+++ b/src/main/java/com/statful/client/framework/springboot/common/ProcessedMetric.java
@@ -1,7 +1,5 @@
 package com.statful.client.framework.springboot.common;
 
-import com.statful.client.domain.api.Aggregation;
-import com.statful.client.domain.api.AggregationFreq;
 import com.statful.client.domain.api.Aggregations;
 import com.statful.client.domain.api.Tags;
 
@@ -104,6 +102,5 @@ public class ProcessedMetric {
         public ProcessedMetric build() {
             return new ProcessedMetric(this);
         }
-
     }
 }

--- a/src/main/java/com/statful/client/framework/springboot/config/SpringbootClientConfiguration.java
+++ b/src/main/java/com/statful/client/framework/springboot/config/SpringbootClientConfiguration.java
@@ -1,0 +1,80 @@
+package com.statful.client.framework.springboot.config;
+
+import com.statful.client.domain.api.StatfulClient;
+import com.statful.client.framework.springboot.writer.StatfulMetricWriter;
+import org.springframework.boot.actuate.autoconfigure.ExportMetricWriter;
+import org.springframework.boot.actuate.endpoint.MetricsEndpoint;
+import org.springframework.boot.actuate.endpoint.MetricsEndpointMetricReader;
+import org.springframework.boot.actuate.metrics.writer.MetricWriter;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import static java.util.Objects.isNull;
+
+@Configuration
+@ConfigurationProperties(prefix = "statful.client.springboot")
+@ConditionalOnBean(value = {StatfulClient.class, MetricWriter.class})
+public class SpringbootClientConfiguration {
+
+    private Metrics metrics;
+
+    public Metrics getMetrics() {
+        return metrics;
+    }
+
+    public void setMetrics(Metrics metrics) {
+        this.metrics = metrics;
+    }
+
+    public static class Metrics {
+        private List<Tags> tags = new ArrayList<>();
+
+        public List<Tags> getTags() {
+            return tags;
+        }
+
+        public void setTags(List<Tags> tags) {
+            this.tags = tags;
+        }
+
+        public static class Tags {
+            private String name;
+            private String value;
+
+            public String getName() {
+                return name;
+            }
+
+            public void setName(String name) {
+                this.name = name;
+            }
+
+            public String getValue() {
+                return value;
+            }
+
+            public void setValue(String value) {
+                this.value = value;
+            }
+        }
+    }
+
+    @Bean
+    @ConditionalOnProperty(value = "statful.client.springboot.metrics.enabled", havingValue = "true")
+    public MetricsEndpointMetricReader metricsEndpointMetricReader(final MetricsEndpoint metricsEndpoint) {
+        return new MetricsEndpointMetricReader(metricsEndpoint);
+    }
+
+    @Bean
+    @ExportMetricWriter
+    MetricWriter metricWriter() {
+        return new StatfulMetricWriter();
+    }
+}

--- a/src/main/java/com/statful/client/framework/springboot/config/SpringbootClientConfiguration.java
+++ b/src/main/java/com/statful/client/framework/springboot/config/SpringbootClientConfiguration.java
@@ -13,10 +13,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
-
-import static java.util.Objects.isNull;
 
 @Configuration
 @ConfigurationProperties(prefix = "statful.client.springboot")

--- a/src/main/java/com/statful/client/framework/springboot/config/SpringbootClientConfiguration.java
+++ b/src/main/java/com/statful/client/framework/springboot/config/SpringbootClientConfiguration.java
@@ -15,6 +15,11 @@ import org.springframework.context.annotation.Configuration;
 import java.util.ArrayList;
 import java.util.List;
 
+/**
+ * Main springboot client configuration class.
+ *
+ * Responsible for initializing metrics reader/writer.
+ */
 @Configuration
 @ConfigurationProperties(prefix = "statful.client.springboot")
 @ConditionalOnBean(value = {StatfulClient.class, MetricWriter.class})
@@ -30,6 +35,9 @@ public class SpringbootClientConfiguration {
         this.metrics = metrics;
     }
 
+    /**
+     * Meta-configuration class.
+     */
     public static class Metrics {
         private List<Tags> tags = new ArrayList<>();
 
@@ -41,6 +49,9 @@ public class SpringbootClientConfiguration {
             this.tags = tags;
         }
 
+        /**
+         * Meta-configuration class.
+         */
         public static class Tags {
             private String name;
             private String value;
@@ -63,12 +74,21 @@ public class SpringbootClientConfiguration {
         }
     }
 
+    /**
+     * Enable a metrics reader.
+     * @param metricsEndpoint {@link MetricsEndpoint}
+     * @return
+     */
     @Bean
     @ConditionalOnProperty(value = "statful.client.springboot.metrics.enabled", havingValue = "true")
     public MetricsEndpointMetricReader metricsEndpointMetricReader(final MetricsEndpoint metricsEndpoint) {
         return new MetricsEndpointMetricReader(metricsEndpoint);
     }
 
+    /**
+     * Export a new {@link StatfulMetricWriter} metrics writer.
+     * @return {@link MetricWriter}
+     */
     @Bean
     @ExportMetricWriter
     MetricWriter metricWriter() {

--- a/src/main/java/com/statful/client/framework/springboot/config/SpringbootClientConfiguration.java
+++ b/src/main/java/com/statful/client/framework/springboot/config/SpringbootClientConfiguration.java
@@ -34,7 +34,7 @@ public class SpringbootClientConfiguration {
         private List<Tags> tags = new ArrayList<>();
 
         public List<Tags> getTags() {
-            return tags;
+            return new ArrayList<>(tags);
         }
 
         public void setTags(List<Tags> tags) {

--- a/src/main/java/com/statful/client/framework/springboot/processor/GenericProcessor.java
+++ b/src/main/java/com/statful/client/framework/springboot/processor/GenericProcessor.java
@@ -3,10 +3,24 @@ package com.statful.client.framework.springboot.processor;
 import com.statful.client.framework.springboot.common.MetricType;
 import com.statful.client.framework.springboot.common.ProcessedMetric;
 
+/**
+ * Generic processor responsible for parsing exported metrics.
+ *
+ * Only useful as an util method.
+ */
 public final class GenericProcessor {
 
     private GenericProcessor() {}
 
+    /**
+     * Processes metric details into a Processed metric.
+     *
+     * @param name {@link String} Metric name
+     * @param metricType {@link MetricType} Metric type
+     * @param value {@link Double} Metric value
+     * @param timestamp {@link long} Metric timestamp
+     * @return {@link ProcessedMetric} Processed metric
+     */
     public static ProcessedMetric process(String name, MetricType metricType, Double value, long timestamp) {
         return new ProcessedMetric.Builder().withName(name)
                 .withMetricType(metricType)

--- a/src/main/java/com/statful/client/framework/springboot/processor/GenericProcessor.java
+++ b/src/main/java/com/statful/client/framework/springboot/processor/GenericProcessor.java
@@ -1,0 +1,15 @@
+package com.statful.client.framework.springboot.processor;
+
+import com.statful.client.framework.springboot.common.MetricType;
+import com.statful.client.framework.springboot.common.ProcessedMetric;
+
+public class GenericProcessor {
+
+    public static ProcessedMetric process(String name, MetricType metricType, Double value, long timestamp) {
+        return new ProcessedMetric.Builder().withName(name)
+                .withMetricType(metricType)
+                .withValue(value)
+                .withTimestamp(timestamp)
+                .build();
+    }
+}

--- a/src/main/java/com/statful/client/framework/springboot/processor/GenericProcessor.java
+++ b/src/main/java/com/statful/client/framework/springboot/processor/GenericProcessor.java
@@ -3,7 +3,7 @@ package com.statful.client.framework.springboot.processor;
 import com.statful.client.framework.springboot.common.MetricType;
 import com.statful.client.framework.springboot.common.ProcessedMetric;
 
-public class GenericProcessor {
+public abstract class GenericProcessor {
 
     public static ProcessedMetric process(String name, MetricType metricType, Double value, long timestamp) {
         return new ProcessedMetric.Builder().withName(name)

--- a/src/main/java/com/statful/client/framework/springboot/processor/GenericProcessor.java
+++ b/src/main/java/com/statful/client/framework/springboot/processor/GenericProcessor.java
@@ -3,7 +3,9 @@ package com.statful.client.framework.springboot.processor;
 import com.statful.client.framework.springboot.common.MetricType;
 import com.statful.client.framework.springboot.common.ProcessedMetric;
 
-public abstract class GenericProcessor {
+public final class GenericProcessor {
+
+    private GenericProcessor() {}
 
     public static ProcessedMetric process(String name, MetricType metricType, Double value, long timestamp) {
         return new ProcessedMetric.Builder().withName(name)

--- a/src/main/java/com/statful/client/framework/springboot/processor/MetricProcessor.java
+++ b/src/main/java/com/statful/client/framework/springboot/processor/MetricProcessor.java
@@ -1,0 +1,22 @@
+package com.statful.client.framework.springboot.processor;
+
+import com.statful.client.framework.springboot.common.ExportedMetric;
+import com.statful.client.framework.springboot.common.ProcessedMetric;
+
+/**
+ * Interface that define the contract for metric processors.
+ */
+public interface MetricProcessor {
+
+    String SYSTEM_METRICS_PREFIX = "system.";
+    String TOMCAT_METRICS_PREFIX = "tomcat.";
+    String ACCUMULATED_METRICS_PREFIX = "accumulated.";
+    String LATEST_METRICS_PREFIX = "latest.";
+
+    /**
+     * Processes that converts an {@link ExportedMetric} into a {@link ProcessedMetric}.
+     * @param exportedMetric Exported metric to process
+     * @return {@link ProcessedMetric} Processed metric
+     */
+    ProcessedMetric process(ExportedMetric exportedMetric);
+}

--- a/src/main/java/com/statful/client/framework/springboot/processor/MetricProcessor.java
+++ b/src/main/java/com/statful/client/framework/springboot/processor/MetricProcessor.java
@@ -3,6 +3,8 @@ package com.statful.client.framework.springboot.processor;
 import com.statful.client.framework.springboot.common.ExportedMetric;
 import com.statful.client.framework.springboot.common.ProcessedMetric;
 
+import java.util.List;
+
 /**
  * Interface that define the contract for metric processors.
  */
@@ -19,4 +21,6 @@ public interface MetricProcessor {
      * @return {@link ProcessedMetric} Processed metric
      */
     ProcessedMetric process(ExportedMetric exportedMetric);
+
+    List<String> getProcessorKeys();
 }

--- a/src/main/java/com/statful/client/framework/springboot/processor/MetricProcessor.java
+++ b/src/main/java/com/statful/client/framework/springboot/processor/MetricProcessor.java
@@ -22,5 +22,9 @@ public interface MetricProcessor {
      */
     ProcessedMetric process(ExportedMetric exportedMetric);
 
+    /**
+     * Returns the list of strings to identify the processor.
+     * @return {@link List}
+     */
     List<String> getProcessorKeys();
 }

--- a/src/main/java/com/statful/client/framework/springboot/processor/ProcessorMap.java
+++ b/src/main/java/com/statful/client/framework/springboot/processor/ProcessorMap.java
@@ -1,49 +1,37 @@
 package com.statful.client.framework.springboot.processor;
 
-import com.statful.client.framework.springboot.processor.processors.http.HttpRequestsProcessor;
-import com.statful.client.framework.springboot.processor.processors.system.*;
-import com.statful.client.framework.springboot.processor.processors.tomcat.HttpSessionsProcessor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
-public abstract class ProcessorMap {
+@Component
+public class ProcessorMap {
 
-    private static Map<String, MetricProcessor> processors;
+    private Map<String, MetricProcessor> processors = new HashMap<>();
 
-    static {
-        processors = new HashMap<>();
-        processors.put("mem", new MemProcessor());
-        processors.put("processors", new ProcessorsProcessor());
-        processors.put("instance", new UptimeProcessor());
-        processors.put("uptime", new UptimeProcessor());
-        processors.put("systemload", new SystemLoadProcessor());
-        processors.put("heap", new HeapProcessor());
-        processors.put("nonheap", new HeapProcessor());
-        processors.put("threads", new ThreadsProcessor());
-        processors.put("classes", new ClassesProcessor());
-        processors.put("gc", new GcProcessor());
-        processors.put("httpsessions", new HttpSessionsProcessor());
-        processors.put("counter.status", new HttpRequestsProcessor());
-        processors.put("gauge.response", new HttpRequestsProcessor());
+    @Autowired
+    protected void setProcessors(List<MetricProcessor> injectedProcessors) {
+        injectedProcessors
+                .forEach(processor -> processor.getProcessorKeys().forEach(key -> processors.put(key, processor)));
     }
 
-    public static MetricProcessor getProcessor(String metric) {
+    public MetricProcessor getProcessor(String metric) {
         Optional<String> mapKey = processors.keySet().stream()
                 .filter(metric::startsWith)
                 .findFirst();
 
-        if (mapKey.isPresent()) {
-            return processors.get(mapKey.get());
-        } else {
-            throw new IllegalArgumentException();
-        }
+        return mapKey.map(processors::get).orElseThrow(IllegalArgumentException::new);
     }
 
-    public static boolean validateProcessor(String metric) {
+    public boolean validateProcessor(String metric) {
         return processors.keySet().stream().anyMatch(metric::startsWith);
+    }
+
+    public Map<String, MetricProcessor> getProcessors() {
+        return new HashMap<>(processors);
     }
 }

--- a/src/main/java/com/statful/client/framework/springboot/processor/ProcessorMap.java
+++ b/src/main/java/com/statful/client/framework/springboot/processor/ProcessorMap.java
@@ -1,0 +1,49 @@
+package com.statful.client.framework.springboot.processor;
+
+import com.statful.client.framework.springboot.processor.processors.http.HttpRequestsProcessor;
+import com.statful.client.framework.springboot.processor.processors.system.*;
+import com.statful.client.framework.springboot.processor.processors.tomcat.HttpSessionsProcessor;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public abstract class ProcessorMap {
+
+    private static Map<String, MetricProcessor> processors;
+
+    static {
+        processors = new HashMap<>();
+        processors.put("mem", new MemProcessor());
+        processors.put("processors", new ProcessorsProcessor());
+        processors.put("instance", new UptimeProcessor());
+        processors.put("uptime", new UptimeProcessor());
+        processors.put("systemload", new SystemLoadProcessor());
+        processors.put("heap", new HeapProcessor());
+        processors.put("nonheap", new HeapProcessor());
+        processors.put("threads", new ThreadsProcessor());
+        processors.put("classes", new ClassesProcessor());
+        processors.put("gc", new GcProcessor());
+        processors.put("httpsessions", new HttpSessionsProcessor());
+        processors.put("counter.status", new HttpRequestsProcessor());
+        processors.put("gauge.response", new HttpRequestsProcessor());
+    }
+
+    public static MetricProcessor getProcessor(String metric) {
+        Optional<String> mapKey = processors.keySet().stream()
+                .filter(metric::startsWith)
+                .findFirst();
+
+        if (mapKey.isPresent()) {
+            return processors.get(mapKey.get());
+        } else {
+            throw new IllegalArgumentException();
+        }
+    }
+
+    public static boolean validateProcessor(String metric) {
+        return processors.keySet().stream().anyMatch(metric::startsWith);
+    }
+}

--- a/src/main/java/com/statful/client/framework/springboot/processor/ProcessorMap.java
+++ b/src/main/java/com/statful/client/framework/springboot/processor/ProcessorMap.java
@@ -8,17 +8,31 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+/**
+ * Class responsible to maintain a map of metric prefixes and correspondent processors.
+ */
 @Component
 public class ProcessorMap {
 
     private Map<String, MetricProcessor> processors = new HashMap<>();
 
+    /**
+     * Sets entries in the processors map based on a list of Metric processors.
+     *
+     * @param injectedProcessors {@link List} List of {@link MetricProcessor} processors
+     */
     @Autowired
     protected void setProcessors(List<MetricProcessor> injectedProcessors) {
         injectedProcessors
                 .forEach(processor -> processor.getProcessorKeys().forEach(key -> processors.put(key, processor)));
     }
 
+    /**
+     * Returns the proper processor for a metric.
+     *
+     * @param metric {@link String} Metric name
+     * @return {@link MetricProcessor} Processor that handles the particular metric
+     */
     public MetricProcessor getProcessor(String metric) {
         Optional<String> mapKey = processors.keySet().stream()
                 .filter(metric::startsWith)
@@ -27,6 +41,12 @@ public class ProcessorMap {
         return mapKey.map(processors::get).orElseThrow(IllegalArgumentException::new);
     }
 
+    /**
+     * Validates if there is a processor for a particular metric.
+     *
+     * @param metric {@link String} Metric name.
+     * @return {@link Boolean} True if a processor exist for a particular metric
+     */
     public boolean validateProcessor(String metric) {
         return processors.keySet().stream().anyMatch(metric::startsWith);
     }

--- a/src/main/java/com/statful/client/framework/springboot/processor/StatfulMetricProcessor.java
+++ b/src/main/java/com/statful/client/framework/springboot/processor/StatfulMetricProcessor.java
@@ -1,0 +1,19 @@
+package com.statful.client.framework.springboot.processor;
+
+import com.statful.client.framework.springboot.common.ExportedMetric;
+import com.statful.client.framework.springboot.common.ProcessedMetric;
+import org.springframework.stereotype.Component;
+
+@Component
+public class StatfulMetricProcessor {
+
+    public static boolean validate(ExportedMetric exportedMetric) {
+        return ProcessorMap.validateProcessor(exportedMetric.getName());
+    }
+
+    public static ProcessedMetric process(ExportedMetric exportedMetric) {
+        MetricProcessor metricProcessor = ProcessorMap.getProcessor(exportedMetric.getName());
+
+        return metricProcessor.process(exportedMetric);
+    }
+}

--- a/src/main/java/com/statful/client/framework/springboot/processor/StatfulMetricProcessor.java
+++ b/src/main/java/com/statful/client/framework/springboot/processor/StatfulMetricProcessor.java
@@ -4,16 +4,25 @@ import com.statful.client.framework.springboot.common.ExportedMetric;
 import com.statful.client.framework.springboot.common.ProcessedMetric;
 import org.springframework.stereotype.Component;
 
+import javax.annotation.Resource;
+
 @Component
 public class StatfulMetricProcessor {
 
+    @Resource
+    private ProcessorMap processorMap;
+
     public boolean validate(ExportedMetric exportedMetric) {
-        return ProcessorMap.validateProcessor(exportedMetric.getName());
+        return processorMap.validateProcessor(exportedMetric.getName());
     }
 
     public ProcessedMetric process(ExportedMetric exportedMetric) {
-        MetricProcessor metricProcessor = ProcessorMap.getProcessor(exportedMetric.getName());
+        MetricProcessor metricProcessor = processorMap.getProcessor(exportedMetric.getName());
 
         return metricProcessor.process(exportedMetric);
+    }
+
+    public void setProcessorMap(ProcessorMap processorMap) {
+        this.processorMap = processorMap;
     }
 }

--- a/src/main/java/com/statful/client/framework/springboot/processor/StatfulMetricProcessor.java
+++ b/src/main/java/com/statful/client/framework/springboot/processor/StatfulMetricProcessor.java
@@ -6,16 +6,33 @@ import org.springframework.stereotype.Component;
 
 import javax.annotation.Resource;
 
+/**
+ * Wrapper class to present processor functionality.
+ *
+ * Responsible to delegate validation and processing to specialized handlers.
+ */
 @Component
 public class StatfulMetricProcessor {
 
     @Resource
     private ProcessorMap processorMap;
 
+    /**
+     * Validates if there is a processor for a particular exported metric.
+     *
+     * @param exportedMetric {@link ExportedMetric} Exported metric
+     * @return {@link Boolean} True if a processor exist for a particular metric
+     */
     public boolean validate(ExportedMetric exportedMetric) {
         return processorMap.validateProcessor(exportedMetric.getName());
     }
 
+    /**
+     * Process a particular exported metric.
+     *
+     * @param exportedMetric {@link ExportedMetric} Exported metric
+     * @return {@link ProcessedMetric} Processed metric
+     */
     public ProcessedMetric process(ExportedMetric exportedMetric) {
         MetricProcessor metricProcessor = processorMap.getProcessor(exportedMetric.getName());
 

--- a/src/main/java/com/statful/client/framework/springboot/processor/StatfulMetricProcessor.java
+++ b/src/main/java/com/statful/client/framework/springboot/processor/StatfulMetricProcessor.java
@@ -7,11 +7,11 @@ import org.springframework.stereotype.Component;
 @Component
 public class StatfulMetricProcessor {
 
-    public static boolean validate(ExportedMetric exportedMetric) {
+    public boolean validate(ExportedMetric exportedMetric) {
         return ProcessorMap.validateProcessor(exportedMetric.getName());
     }
 
-    public static ProcessedMetric process(ExportedMetric exportedMetric) {
+    public ProcessedMetric process(ExportedMetric exportedMetric) {
         MetricProcessor metricProcessor = ProcessorMap.getProcessor(exportedMetric.getName());
 
         return metricProcessor.process(exportedMetric);

--- a/src/main/java/com/statful/client/framework/springboot/processor/processors/http/HttpRequestsProcessor.java
+++ b/src/main/java/com/statful/client/framework/springboot/processor/processors/http/HttpRequestsProcessor.java
@@ -5,13 +5,14 @@ import com.statful.client.framework.springboot.common.ExportedMetric;
 import com.statful.client.framework.springboot.common.MetricType;
 import com.statful.client.framework.springboot.common.ProcessedMetric;
 import com.statful.client.framework.springboot.processor.MetricProcessor;
-import org.springframework.beans.factory.annotation.Value;
 
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public class HttpRequestsProcessor implements MetricProcessor {
 
+    private static final String REQUESTS_NAME = ACCUMULATED_METRICS_PREFIX + "requests";
+    private static final String RESPONSES_NAME = LATEST_METRICS_PREFIX + "responses";
     private static Pattern COUNTER_STATUS_PATTERN = Pattern.compile("^counter\\.status\\.(\\d{3})\\.(.+)$");
     private static Pattern GAUGE_RESPONSE_PATTERN = Pattern.compile("^gauge\\.response\\.(.+)$");
 
@@ -45,7 +46,7 @@ public class HttpRequestsProcessor implements MetricProcessor {
         tags.putTag("status", status);
         tags.putTag("url", url);
 
-        return new ProcessedMetric.Builder().withName(ACCUMULATED_METRICS_PREFIX + "requests")
+        return new ProcessedMetric.Builder().withName(REQUESTS_NAME)
                 .withTags(tags)
                 .withMetricType(MetricType.COUNTER)
                 .withValue(exportedMetric.getValue().doubleValue())
@@ -57,7 +58,7 @@ public class HttpRequestsProcessor implements MetricProcessor {
         Tags tags = new Tags();
         tags.putTag("url", url);
 
-        return new ProcessedMetric.Builder().withName(LATEST_METRICS_PREFIX + "responses")
+        return new ProcessedMetric.Builder().withName(RESPONSES_NAME)
                 .withTags(tags)
                 .withMetricType(MetricType.TIMER)
                 .withValue(exportedMetric.getValue().doubleValue())

--- a/src/main/java/com/statful/client/framework/springboot/processor/processors/http/HttpRequestsProcessor.java
+++ b/src/main/java/com/statful/client/framework/springboot/processor/processors/http/HttpRequestsProcessor.java
@@ -1,0 +1,74 @@
+package com.statful.client.framework.springboot.processor.processors.http;
+
+import com.statful.client.domain.api.Tags;
+import com.statful.client.framework.springboot.common.ExportedMetric;
+import com.statful.client.framework.springboot.common.MetricType;
+import com.statful.client.framework.springboot.common.ProcessedMetric;
+import com.statful.client.framework.springboot.processor.MetricProcessor;
+import org.springframework.beans.factory.annotation.Value;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class HttpRequestsProcessor implements MetricProcessor {
+
+    private static Pattern COUNTER_STATUS_PATTERN = Pattern.compile("^counter\\.status\\.(\\d{3})\\.(.+)$");
+    private static Pattern GAUGE_RESPONSE_PATTERN = Pattern.compile("^gauge\\.response\\.(.+)$");
+
+    @Value("${statful.client.springboot.metrics.units.enabled.enabled:false}")
+    private boolean unitsEnabled;
+
+    @Override
+    public ProcessedMetric process(ExportedMetric exportedMetric) {
+        /**
+         * Example:
+         *  counter.status.200.root=20
+         *  counter.status.200.metrics=3
+         *  counter.status.200.star-star.favicon.ico=5
+         *  counter.status.401.root=4
+         *  gauge.response.star-star.favicon.ico=6
+         *  gauge.response.root=2
+         *  gauge.response.metrics=3
+         */
+
+        Matcher counterMatcher = COUNTER_STATUS_PATTERN.matcher(exportedMetric.getName());
+        Matcher gaugeMatcher = GAUGE_RESPONSE_PATTERN.matcher(exportedMetric.getName());
+
+        if (counterMatcher.matches()) {
+            return processCounter(counterMatcher.group(1), counterMatcher.group(2), exportedMetric);
+        } else if (gaugeMatcher.matches()) {
+            return processGauge(gaugeMatcher.group(1), exportedMetric);
+        } else {
+            throw new IllegalArgumentException();
+        }
+    }
+
+    private ProcessedMetric processCounter(String status, String url, ExportedMetric exportedMetric) {
+        Tags tags = new Tags();
+        tags.putTag("status", status);
+        tags.putTag("url", url);
+
+        return new ProcessedMetric.Builder().withName(ACCUMULATED_METRICS_PREFIX + "requests")
+                .withTags(tags)
+                .withMetricType(MetricType.COUNTER)
+                .withValue(exportedMetric.getValue().doubleValue())
+                .withTimestamp(exportedMetric.getTimestamp().getTime())
+                .build();
+    }
+
+    private ProcessedMetric processGauge(String url, ExportedMetric exportedMetric) {
+        Tags tags = new Tags();
+        tags.putTag("url", url);
+
+        if (unitsEnabled) {
+            tags.putTag("unit", "ms");
+        }
+
+        return new ProcessedMetric.Builder().withName(LATEST_METRICS_PREFIX + "responses")
+                .withTags(tags)
+                .withMetricType(MetricType.TIMER)
+                .withValue(exportedMetric.getValue().doubleValue())
+                .withTimestamp(exportedMetric.getTimestamp().getTime())
+                .build();
+    }
+}

--- a/src/main/java/com/statful/client/framework/springboot/processor/processors/http/HttpRequestsProcessor.java
+++ b/src/main/java/com/statful/client/framework/springboot/processor/processors/http/HttpRequestsProcessor.java
@@ -5,10 +5,17 @@ import com.statful.client.framework.springboot.common.ExportedMetric;
 import com.statful.client.framework.springboot.common.MetricType;
 import com.statful.client.framework.springboot.common.ProcessedMetric;
 import com.statful.client.framework.springboot.processor.MetricProcessor;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
 
+import java.util.LinkedList;
+import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+@Component
+@ConditionalOnProperty(name = "statful.client.springboot.processors.http.httpRequests.enabled",
+        havingValue = "true", matchIfMissing = true)
 public class HttpRequestsProcessor implements MetricProcessor {
 
     private static final String REQUESTS_NAME = ACCUMULATED_METRICS_PREFIX + "requests";
@@ -39,6 +46,15 @@ public class HttpRequestsProcessor implements MetricProcessor {
         } else {
             throw new IllegalArgumentException();
         }
+    }
+
+    @Override
+    public List<String> getProcessorKeys() {
+        List<String> keys = new LinkedList<>();
+        keys.add("counter.status");
+        keys.add("gauge.response");
+
+        return keys;
     }
 
     private ProcessedMetric processCounter(String status, String url, ExportedMetric exportedMetric) {

--- a/src/main/java/com/statful/client/framework/springboot/processor/processors/http/HttpRequestsProcessor.java
+++ b/src/main/java/com/statful/client/framework/springboot/processor/processors/http/HttpRequestsProcessor.java
@@ -13,6 +13,18 @@ import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+/**
+ * Processor responsible for parsing exported http request metrics.
+ *
+ * Example:
+ *  counter.status.200.root=20
+ *  counter.status.200.metrics=3
+ *  counter.status.200.star-star.favicon.ico=5
+ *  counter.status.401.root=4
+ *  gauge.response.star-star.favicon.ico=6
+ *  gauge.response.root=2
+ *  gauge.response.metrics=3
+ */
 @Component
 @ConditionalOnProperty(name = "statful.client.springboot.processors.http.httpRequests.enabled",
         havingValue = "true", matchIfMissing = true)
@@ -25,17 +37,6 @@ public class HttpRequestsProcessor implements MetricProcessor {
 
     @Override
     public ProcessedMetric process(ExportedMetric exportedMetric) {
-        /**
-         * Example:
-         *  counter.status.200.root=20
-         *  counter.status.200.metrics=3
-         *  counter.status.200.star-star.favicon.ico=5
-         *  counter.status.401.root=4
-         *  gauge.response.star-star.favicon.ico=6
-         *  gauge.response.root=2
-         *  gauge.response.metrics=3
-         */
-
         Matcher counterMatcher = COUNTER_STATUS_PATTERN.matcher(exportedMetric.getName());
         Matcher gaugeMatcher = GAUGE_RESPONSE_PATTERN.matcher(exportedMetric.getName());
 

--- a/src/main/java/com/statful/client/framework/springboot/processor/processors/http/HttpRequestsProcessor.java
+++ b/src/main/java/com/statful/client/framework/springboot/processor/processors/http/HttpRequestsProcessor.java
@@ -15,9 +15,6 @@ public class HttpRequestsProcessor implements MetricProcessor {
     private static Pattern COUNTER_STATUS_PATTERN = Pattern.compile("^counter\\.status\\.(\\d{3})\\.(.+)$");
     private static Pattern GAUGE_RESPONSE_PATTERN = Pattern.compile("^gauge\\.response\\.(.+)$");
 
-    @Value("${statful.client.springboot.metrics.units.enabled.enabled:false}")
-    private boolean unitsEnabled;
-
     @Override
     public ProcessedMetric process(ExportedMetric exportedMetric) {
         /**
@@ -59,10 +56,6 @@ public class HttpRequestsProcessor implements MetricProcessor {
     private ProcessedMetric processGauge(String url, ExportedMetric exportedMetric) {
         Tags tags = new Tags();
         tags.putTag("url", url);
-
-        if (unitsEnabled) {
-            tags.putTag("unit", "ms");
-        }
 
         return new ProcessedMetric.Builder().withName(LATEST_METRICS_PREFIX + "responses")
                 .withTags(tags)

--- a/src/main/java/com/statful/client/framework/springboot/processor/processors/system/ClassesProcessor.java
+++ b/src/main/java/com/statful/client/framework/springboot/processor/processors/system/ClassesProcessor.java
@@ -8,6 +8,8 @@ import com.statful.client.framework.springboot.processor.MetricProcessor;
 
 public class ClassesProcessor implements MetricProcessor {
 
+    private static final Tags TOTAL_TYPE_TAGS = Tags.from("type", "total");
+
     @Override
     public ProcessedMetric process(ExportedMetric exportedMetric) {
         /**
@@ -22,7 +24,7 @@ public class ClassesProcessor implements MetricProcessor {
 
         switch (metricSplit.length) {
             case 1:
-                tags = Tags.from("type", "total");
+                tags = TOTAL_TYPE_TAGS;
                 break;
             case 2:
                 tags = Tags.from("type", metricSplit[1]);

--- a/src/main/java/com/statful/client/framework/springboot/processor/processors/system/ClassesProcessor.java
+++ b/src/main/java/com/statful/client/framework/springboot/processor/processors/system/ClassesProcessor.java
@@ -5,7 +5,15 @@ import com.statful.client.framework.springboot.common.ExportedMetric;
 import com.statful.client.framework.springboot.common.MetricType;
 import com.statful.client.framework.springboot.common.ProcessedMetric;
 import com.statful.client.framework.springboot.processor.MetricProcessor;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
 
+import java.util.Collections;
+import java.util.List;
+
+@Component
+@ConditionalOnProperty(name = "statful.client.springboot.processors.system.classes.enabled",
+        havingValue = "true", matchIfMissing = true)
 public class ClassesProcessor implements MetricProcessor {
 
     private static final Tags TOTAL_TYPE_TAGS = Tags.from("type", "total");
@@ -39,5 +47,10 @@ public class ClassesProcessor implements MetricProcessor {
                 .withValue(exportedMetric.getValue().doubleValue())
                 .withTimestamp(exportedMetric.getTimestamp().getTime())
                 .build();
+    }
+
+    @Override
+    public List<String> getProcessorKeys() {
+        return Collections.singletonList("classes");
     }
 }

--- a/src/main/java/com/statful/client/framework/springboot/processor/processors/system/ClassesProcessor.java
+++ b/src/main/java/com/statful/client/framework/springboot/processor/processors/system/ClassesProcessor.java
@@ -1,0 +1,41 @@
+package com.statful.client.framework.springboot.processor.processors.system;
+
+import com.statful.client.domain.api.Tags;
+import com.statful.client.framework.springboot.common.ExportedMetric;
+import com.statful.client.framework.springboot.common.MetricType;
+import com.statful.client.framework.springboot.common.ProcessedMetric;
+import com.statful.client.framework.springboot.processor.MetricProcessor;
+
+public class ClassesProcessor implements MetricProcessor {
+
+    @Override
+    public ProcessedMetric process(ExportedMetric exportedMetric) {
+        /**
+         * Example:
+         *   classes=6366
+         *   classes.loaded=6367
+         *   classes.unloaded=1
+         */
+        String[] metricSplit = exportedMetric.getName().split("\\.");
+
+        Tags tags;
+
+        switch (metricSplit.length) {
+            case 1:
+                tags = Tags.from("type", "total");
+                break;
+            case 2:
+                tags = Tags.from("type", metricSplit[1]);
+                break;
+            default:
+                throw new IllegalArgumentException();
+        }
+
+        return new ProcessedMetric.Builder().withName(SYSTEM_METRICS_PREFIX + metricSplit[0])
+                .withTags(tags)
+                .withMetricType(MetricType.GAUGE)
+                .withValue(exportedMetric.getValue().doubleValue())
+                .withTimestamp(exportedMetric.getTimestamp().getTime())
+                .build();
+    }
+}

--- a/src/main/java/com/statful/client/framework/springboot/processor/processors/system/ClassesProcessor.java
+++ b/src/main/java/com/statful/client/framework/springboot/processor/processors/system/ClassesProcessor.java
@@ -11,6 +11,14 @@ import org.springframework.stereotype.Component;
 import java.util.Collections;
 import java.util.List;
 
+/**
+ * Processor responsible for parsing exported classes metrics.
+ *
+ * Example:
+ *   classes=6366
+ *   classes.loaded=6367
+ *   classes.unloaded=1
+ */
 @Component
 @ConditionalOnProperty(name = "statful.client.springboot.processors.system.classes.enabled",
         havingValue = "true", matchIfMissing = true)
@@ -20,12 +28,6 @@ public class ClassesProcessor implements MetricProcessor {
 
     @Override
     public ProcessedMetric process(ExportedMetric exportedMetric) {
-        /**
-         * Example:
-         *   classes=6366
-         *   classes.loaded=6367
-         *   classes.unloaded=1
-         */
         String[] metricSplit = exportedMetric.getName().split("\\.");
 
         Tags tags;

--- a/src/main/java/com/statful/client/framework/springboot/processor/processors/system/GcProcessor.java
+++ b/src/main/java/com/statful/client/framework/springboot/processor/processors/system/GcProcessor.java
@@ -1,0 +1,50 @@
+package com.statful.client.framework.springboot.processor.processors.system;
+
+import com.statful.client.domain.api.Tags;
+import com.statful.client.framework.springboot.common.ExportedMetric;
+import com.statful.client.framework.springboot.common.MetricType;
+import com.statful.client.framework.springboot.common.ProcessedMetric;
+import com.statful.client.framework.springboot.processor.MetricProcessor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+public class GcProcessor implements MetricProcessor {
+
+    @Value("${statful.client.springboot.metrics.units.enabled:false}")
+    private boolean unitsEnabled;
+
+    @Override
+    public ProcessedMetric process(ExportedMetric exportedMetric) {
+        /**
+         * Example:
+         *  gc.ps_scavenge.count=5
+         *  gc.ps_scavenge.time=55
+         */
+        String[] metricSplit = exportedMetric.getName().split("\\.");
+
+        Tags tags = Tags.from("name", metricSplit[1]);
+
+        MetricType metricType;
+
+        switch (metricSplit[2]) {
+            case "count":
+                metricType = MetricType.COUNTER;
+                break;
+            case "time":
+                metricType = MetricType.TIMER;
+                if (unitsEnabled) {
+                    tags.putTag("unit", "ms");
+                }
+                break;
+            default:
+                throw new IllegalArgumentException();
+        }
+
+        return new ProcessedMetric.Builder().withName(SYSTEM_METRICS_PREFIX + ACCUMULATED_METRICS_PREFIX + metricSplit[0])
+                .withTags(tags)
+                .withMetricType(metricType)
+                .withValue(exportedMetric.getValue().doubleValue())
+                .withTimestamp(exportedMetric.getTimestamp().getTime())
+                .build();
+    }
+}

--- a/src/main/java/com/statful/client/framework/springboot/processor/processors/system/GcProcessor.java
+++ b/src/main/java/com/statful/client/framework/springboot/processor/processors/system/GcProcessor.java
@@ -5,7 +5,15 @@ import com.statful.client.framework.springboot.common.ExportedMetric;
 import com.statful.client.framework.springboot.common.MetricType;
 import com.statful.client.framework.springboot.common.ProcessedMetric;
 import com.statful.client.framework.springboot.processor.MetricProcessor;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
 
+import java.util.Collections;
+import java.util.List;
+
+@Component
+@ConditionalOnProperty(name = "statful.client.springboot.processors.system.gc.enabled",
+        havingValue = "true", matchIfMissing = true)
 public class GcProcessor implements MetricProcessor {
 
     @Override
@@ -42,5 +50,10 @@ public class GcProcessor implements MetricProcessor {
                 .withValue(exportedMetric.getValue().doubleValue())
                 .withTimestamp(exportedMetric.getTimestamp().getTime())
                 .build();
+    }
+
+    @Override
+    public List<String> getProcessorKeys() {
+        return Collections.singletonList("gc");
     }
 }

--- a/src/main/java/com/statful/client/framework/springboot/processor/processors/system/GcProcessor.java
+++ b/src/main/java/com/statful/client/framework/springboot/processor/processors/system/GcProcessor.java
@@ -10,9 +10,6 @@ import org.springframework.stereotype.Component;
 
 public class GcProcessor implements MetricProcessor {
 
-    @Value("${statful.client.springboot.metrics.units.enabled:false}")
-    private boolean unitsEnabled;
-
     @Override
     public ProcessedMetric process(ExportedMetric exportedMetric) {
         /**
@@ -32,9 +29,6 @@ public class GcProcessor implements MetricProcessor {
                 break;
             case "time":
                 metricType = MetricType.TIMER;
-                if (unitsEnabled) {
-                    tags.putTag("unit", "ms");
-                }
                 break;
             default:
                 throw new IllegalArgumentException();

--- a/src/main/java/com/statful/client/framework/springboot/processor/processors/system/GcProcessor.java
+++ b/src/main/java/com/statful/client/framework/springboot/processor/processors/system/GcProcessor.java
@@ -5,8 +5,6 @@ import com.statful.client.framework.springboot.common.ExportedMetric;
 import com.statful.client.framework.springboot.common.MetricType;
 import com.statful.client.framework.springboot.common.ProcessedMetric;
 import com.statful.client.framework.springboot.processor.MetricProcessor;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.stereotype.Component;
 
 public class GcProcessor implements MetricProcessor {
 
@@ -18,6 +16,10 @@ public class GcProcessor implements MetricProcessor {
          *  gc.ps_scavenge.time=55
          */
         String[] metricSplit = exportedMetric.getName().split("\\.");
+
+        if (metricSplit.length != 3) {
+            throw  new IllegalArgumentException();
+        }
 
         Tags tags = Tags.from("name", metricSplit[1]);
 

--- a/src/main/java/com/statful/client/framework/springboot/processor/processors/system/GcProcessor.java
+++ b/src/main/java/com/statful/client/framework/springboot/processor/processors/system/GcProcessor.java
@@ -11,6 +11,13 @@ import org.springframework.stereotype.Component;
 import java.util.Collections;
 import java.util.List;
 
+/**
+ * Processor responsible for parsing exported gc metrics.
+ *
+ * Example:
+ *  gc.ps_scavenge.count=5
+ *  gc.ps_scavenge.time=55
+ */
 @Component
 @ConditionalOnProperty(name = "statful.client.springboot.processors.system.gc.enabled",
         havingValue = "true", matchIfMissing = true)
@@ -18,11 +25,6 @@ public class GcProcessor implements MetricProcessor {
 
     @Override
     public ProcessedMetric process(ExportedMetric exportedMetric) {
-        /**
-         * Example:
-         *  gc.ps_scavenge.count=5
-         *  gc.ps_scavenge.time=55
-         */
         String[] metricSplit = exportedMetric.getName().split("\\.");
 
         if (metricSplit.length != 3) {

--- a/src/main/java/com/statful/client/framework/springboot/processor/processors/system/HeapProcessor.java
+++ b/src/main/java/com/statful/client/framework/springboot/processor/processors/system/HeapProcessor.java
@@ -9,9 +9,6 @@ import org.springframework.beans.factory.annotation.Value;
 
 public class HeapProcessor implements MetricProcessor {
 
-    @Value("${statful.client.springboot.metrics.units.enabled:false}")
-    private boolean unitsEnabled;
-
     @Override
     public ProcessedMetric process(ExportedMetric exportedMetric) {
         /**
@@ -34,10 +31,6 @@ public class HeapProcessor implements MetricProcessor {
                 break;
             default:
                 throw new IllegalArgumentException();
-        }
-
-        if (unitsEnabled) {
-            tags.putTag("unit", "KB");
         }
 
         return new ProcessedMetric.Builder().withName(SYSTEM_METRICS_PREFIX + metricSplit[0])

--- a/src/main/java/com/statful/client/framework/springboot/processor/processors/system/HeapProcessor.java
+++ b/src/main/java/com/statful/client/framework/springboot/processor/processors/system/HeapProcessor.java
@@ -5,9 +5,10 @@ import com.statful.client.framework.springboot.common.ExportedMetric;
 import com.statful.client.framework.springboot.common.MetricType;
 import com.statful.client.framework.springboot.common.ProcessedMetric;
 import com.statful.client.framework.springboot.processor.MetricProcessor;
-import org.springframework.beans.factory.annotation.Value;
 
 public class HeapProcessor implements MetricProcessor {
+
+    private static final Tags MAX_TYPE_TAGS = Tags.from("type", "max");
 
     @Override
     public ProcessedMetric process(ExportedMetric exportedMetric) {
@@ -24,7 +25,7 @@ public class HeapProcessor implements MetricProcessor {
 
         switch (metricSplit.length) {
             case 1:
-                tags = Tags.from("type", "max");
+                tags = MAX_TYPE_TAGS;
                 break;
             case 2:
                 tags = Tags.from("type", metricSplit[1]);

--- a/src/main/java/com/statful/client/framework/springboot/processor/processors/system/HeapProcessor.java
+++ b/src/main/java/com/statful/client/framework/springboot/processor/processors/system/HeapProcessor.java
@@ -11,6 +11,15 @@ import org.springframework.stereotype.Component;
 import java.util.LinkedList;
 import java.util.List;
 
+/**
+ * Processor responsible for parsing exported heap metrics.
+ *
+ * Example:
+ *  heap.committed=389632
+ *  heap.init=262144
+ *  heap.used=131031
+ *  heap=3728384
+ */
 @Component
 @ConditionalOnProperty(name = "statful.client.springboot.processors.system.heap.enabled",
         havingValue = "true", matchIfMissing = true)
@@ -20,13 +29,6 @@ public class HeapProcessor implements MetricProcessor {
 
     @Override
     public ProcessedMetric process(ExportedMetric exportedMetric) {
-        /**
-         * Example:
-         *  heap.committed=389632
-         *  heap.init=262144
-         *  heap.used=131031
-         *  heap=3728384
-         */
         String[] metricSplit = exportedMetric.getName().split("\\.");
 
         Tags tags;

--- a/src/main/java/com/statful/client/framework/springboot/processor/processors/system/HeapProcessor.java
+++ b/src/main/java/com/statful/client/framework/springboot/processor/processors/system/HeapProcessor.java
@@ -5,7 +5,15 @@ import com.statful.client.framework.springboot.common.ExportedMetric;
 import com.statful.client.framework.springboot.common.MetricType;
 import com.statful.client.framework.springboot.common.ProcessedMetric;
 import com.statful.client.framework.springboot.processor.MetricProcessor;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
 
+import java.util.LinkedList;
+import java.util.List;
+
+@Component
+@ConditionalOnProperty(name = "statful.client.springboot.processors.system.heap.enabled",
+        havingValue = "true", matchIfMissing = true)
 public class HeapProcessor implements MetricProcessor {
 
     private static final Tags MAX_TYPE_TAGS = Tags.from("type", "max");
@@ -40,5 +48,13 @@ public class HeapProcessor implements MetricProcessor {
                 .withValue(exportedMetric.getValue().doubleValue())
                 .withTimestamp(exportedMetric.getTimestamp().getTime())
                 .build();
+    }
+
+    @Override
+    public List<String> getProcessorKeys() {
+        List<String> keys = new LinkedList<>();
+        keys.add("heap");
+        keys.add("nonheap");
+        return keys;
     }
 }

--- a/src/main/java/com/statful/client/framework/springboot/processor/processors/system/HeapProcessor.java
+++ b/src/main/java/com/statful/client/framework/springboot/processor/processors/system/HeapProcessor.java
@@ -1,0 +1,50 @@
+package com.statful.client.framework.springboot.processor.processors.system;
+
+import com.statful.client.domain.api.Tags;
+import com.statful.client.framework.springboot.common.ExportedMetric;
+import com.statful.client.framework.springboot.common.MetricType;
+import com.statful.client.framework.springboot.common.ProcessedMetric;
+import com.statful.client.framework.springboot.processor.MetricProcessor;
+import org.springframework.beans.factory.annotation.Value;
+
+public class HeapProcessor implements MetricProcessor {
+
+    @Value("${statful.client.springboot.metrics.units.enabled:false}")
+    private boolean unitsEnabled;
+
+    @Override
+    public ProcessedMetric process(ExportedMetric exportedMetric) {
+        /**
+         * Example:
+         *  heap.committed=389632
+         *  heap.init=262144
+         *  heap.used=131031
+         *  heap=3728384
+         */
+        String[] metricSplit = exportedMetric.getName().split("\\.");
+
+        Tags tags;
+
+        switch (metricSplit.length) {
+            case 1:
+                tags = Tags.from("type", "max");
+                break;
+            case 2:
+                tags = Tags.from("type", metricSplit[1]);
+                break;
+            default:
+                throw new IllegalArgumentException();
+        }
+
+        if (unitsEnabled) {
+            tags.putTag("unit", "KB");
+        }
+
+        return new ProcessedMetric.Builder().withName(SYSTEM_METRICS_PREFIX + metricSplit[0])
+                .withTags(tags)
+                .withMetricType(MetricType.GAUGE)
+                .withValue(exportedMetric.getValue().doubleValue())
+                .withTimestamp(exportedMetric.getTimestamp().getTime())
+                .build();
+    }
+}

--- a/src/main/java/com/statful/client/framework/springboot/processor/processors/system/MemProcessor.java
+++ b/src/main/java/com/statful/client/framework/springboot/processor/processors/system/MemProcessor.java
@@ -11,6 +11,13 @@ import org.springframework.stereotype.Component;
 import java.util.Collections;
 import java.util.List;
 
+/**
+ * Processor responsible for parsing exported mem metrics.
+ *
+ * Example:
+ *  mem.free=258600
+ *  mem=442414
+ */
 @Component
 @ConditionalOnProperty(name = "statful.client.springboot.processors.system.mem.enabled",
         havingValue = "true", matchIfMissing = true)
@@ -20,11 +27,6 @@ public class MemProcessor implements MetricProcessor {
 
     @Override
     public ProcessedMetric process(ExportedMetric exportedMetric) {
-        /**
-         * Example:
-         *  mem.free=258600
-         *  mem=442414
-         */
         String[] metricSplit = exportedMetric.getName().split("\\.");
 
         Tags tags;

--- a/src/main/java/com/statful/client/framework/springboot/processor/processors/system/MemProcessor.java
+++ b/src/main/java/com/statful/client/framework/springboot/processor/processors/system/MemProcessor.java
@@ -5,7 +5,15 @@ import com.statful.client.framework.springboot.common.ExportedMetric;
 import com.statful.client.framework.springboot.common.MetricType;
 import com.statful.client.framework.springboot.common.ProcessedMetric;
 import com.statful.client.framework.springboot.processor.MetricProcessor;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
 
+import java.util.Collections;
+import java.util.List;
+
+@Component
+@ConditionalOnProperty(name = "statful.client.springboot.processors.system.mem.enabled",
+        havingValue = "true", matchIfMissing = true)
 public class MemProcessor implements MetricProcessor {
 
     private static final Tags TOTAL_TYPE_TAGS = Tags.from("type", "total");
@@ -37,5 +45,10 @@ public class MemProcessor implements MetricProcessor {
                 .withValue(exportedMetric.getValue().doubleValue())
                 .withTimestamp(exportedMetric.getTimestamp().getTime())
                 .build();
+    }
+
+    @Override
+    public List<String> getProcessorKeys() {
+        return Collections.singletonList("mem");
     }
 }

--- a/src/main/java/com/statful/client/framework/springboot/processor/processors/system/MemProcessor.java
+++ b/src/main/java/com/statful/client/framework/springboot/processor/processors/system/MemProcessor.java
@@ -1,17 +1,20 @@
 package com.statful.client.framework.springboot.processor.processors.system;
 
 import com.statful.client.domain.api.Tags;
-import com.statful.client.framework.springboot.common.MetricType;
 import com.statful.client.framework.springboot.common.ExportedMetric;
+import com.statful.client.framework.springboot.common.MetricType;
 import com.statful.client.framework.springboot.common.ProcessedMetric;
 import com.statful.client.framework.springboot.processor.MetricProcessor;
-import org.springframework.beans.factory.annotation.Value;
 
 public class MemProcessor implements MetricProcessor {
 
     @Override
     public ProcessedMetric process(ExportedMetric exportedMetric) {
-        // Example: mem.free=442414
+        /**
+         * Example:
+         *  mem.free=258600
+         *  mem=442414
+         */
         String[] metricSplit = exportedMetric.getName().split("\\.");
 
         Tags tags;

--- a/src/main/java/com/statful/client/framework/springboot/processor/processors/system/MemProcessor.java
+++ b/src/main/java/com/statful/client/framework/springboot/processor/processors/system/MemProcessor.java
@@ -8,6 +8,8 @@ import com.statful.client.framework.springboot.processor.MetricProcessor;
 
 public class MemProcessor implements MetricProcessor {
 
+    private static final Tags TOTAL_TYPE_TAGS = Tags.from("type", "total");
+
     @Override
     public ProcessedMetric process(ExportedMetric exportedMetric) {
         /**
@@ -20,7 +22,7 @@ public class MemProcessor implements MetricProcessor {
         Tags tags;
         switch (metricSplit.length) {
             case 1:
-                tags = Tags.from("type", "total");
+                tags = TOTAL_TYPE_TAGS;
                 break;
             case 2:
                 tags = Tags.from("type", metricSplit[1]);

--- a/src/main/java/com/statful/client/framework/springboot/processor/processors/system/MemProcessor.java
+++ b/src/main/java/com/statful/client/framework/springboot/processor/processors/system/MemProcessor.java
@@ -1,0 +1,43 @@
+package com.statful.client.framework.springboot.processor.processors.system;
+
+import com.statful.client.domain.api.Tags;
+import com.statful.client.framework.springboot.common.MetricType;
+import com.statful.client.framework.springboot.common.ExportedMetric;
+import com.statful.client.framework.springboot.common.ProcessedMetric;
+import com.statful.client.framework.springboot.processor.MetricProcessor;
+import org.springframework.beans.factory.annotation.Value;
+
+public class MemProcessor implements MetricProcessor {
+
+    @Value("${statful.client.springboot.metrics.units.enabled:false}")
+    private boolean unitsEnabled;
+
+    @Override
+    public ProcessedMetric process(ExportedMetric exportedMetric) {
+        // Example: mem.free=442414
+        String[] metricSplit = exportedMetric.getName().split("\\.");
+
+        Tags tags;
+        switch (metricSplit.length) {
+            case 1:
+                tags = Tags.from("type", "total");
+                break;
+            case 2:
+                tags = Tags.from("type", metricSplit[1]);
+                break;
+            default:
+                throw new IllegalArgumentException();
+        }
+
+        if (unitsEnabled) {
+            tags.putTag("unit", "KB");
+        }
+
+        return new ProcessedMetric.Builder().withName(SYSTEM_METRICS_PREFIX + metricSplit[0])
+                .withTags(tags)
+                .withMetricType(MetricType.GAUGE)
+                .withValue(exportedMetric.getValue().doubleValue())
+                .withTimestamp(exportedMetric.getTimestamp().getTime())
+                .build();
+    }
+}

--- a/src/main/java/com/statful/client/framework/springboot/processor/processors/system/MemProcessor.java
+++ b/src/main/java/com/statful/client/framework/springboot/processor/processors/system/MemProcessor.java
@@ -9,9 +9,6 @@ import org.springframework.beans.factory.annotation.Value;
 
 public class MemProcessor implements MetricProcessor {
 
-    @Value("${statful.client.springboot.metrics.units.enabled:false}")
-    private boolean unitsEnabled;
-
     @Override
     public ProcessedMetric process(ExportedMetric exportedMetric) {
         // Example: mem.free=442414
@@ -27,10 +24,6 @@ public class MemProcessor implements MetricProcessor {
                 break;
             default:
                 throw new IllegalArgumentException();
-        }
-
-        if (unitsEnabled) {
-            tags.putTag("unit", "KB");
         }
 
         return new ProcessedMetric.Builder().withName(SYSTEM_METRICS_PREFIX + metricSplit[0])

--- a/src/main/java/com/statful/client/framework/springboot/processor/processors/system/ProcessorsProcessor.java
+++ b/src/main/java/com/statful/client/framework/springboot/processor/processors/system/ProcessorsProcessor.java
@@ -11,6 +11,12 @@ import org.springframework.stereotype.Component;
 import java.util.Collections;
 import java.util.List;
 
+/**
+ * Processor responsible for parsing exported processors metrics.
+ *
+ * Example:
+ *  processors=8
+ */
 @Component
 @ConditionalOnProperty(name = "statful.client.springboot.processors.system.processors.enabled",
         havingValue = "true", matchIfMissing = true)
@@ -18,7 +24,6 @@ public class ProcessorsProcessor implements MetricProcessor {
 
     @Override
     public ProcessedMetric process(ExportedMetric exportedMetric) {
-        // Example: processors=8
         return GenericProcessor.process(SYSTEM_METRICS_PREFIX + exportedMetric.getName(),
                 MetricType.GAUGE, exportedMetric.getValue().doubleValue(), exportedMetric.getTimestamp().getTime());
     }

--- a/src/main/java/com/statful/client/framework/springboot/processor/processors/system/ProcessorsProcessor.java
+++ b/src/main/java/com/statful/client/framework/springboot/processor/processors/system/ProcessorsProcessor.java
@@ -1,0 +1,17 @@
+package com.statful.client.framework.springboot.processor.processors.system;
+
+import com.statful.client.framework.springboot.common.ExportedMetric;
+import com.statful.client.framework.springboot.common.MetricType;
+import com.statful.client.framework.springboot.common.ProcessedMetric;
+import com.statful.client.framework.springboot.processor.GenericProcessor;
+import com.statful.client.framework.springboot.processor.MetricProcessor;
+
+public class ProcessorsProcessor implements MetricProcessor {
+
+    @Override
+    public ProcessedMetric process(ExportedMetric exportedMetric) {
+        // Example: processors=8
+        return GenericProcessor.process(SYSTEM_METRICS_PREFIX + exportedMetric.getName(),
+                MetricType.GAUGE, exportedMetric.getValue().doubleValue(), exportedMetric.getTimestamp().getTime());
+    }
+}

--- a/src/main/java/com/statful/client/framework/springboot/processor/processors/system/ProcessorsProcessor.java
+++ b/src/main/java/com/statful/client/framework/springboot/processor/processors/system/ProcessorsProcessor.java
@@ -5,7 +5,15 @@ import com.statful.client.framework.springboot.common.MetricType;
 import com.statful.client.framework.springboot.common.ProcessedMetric;
 import com.statful.client.framework.springboot.processor.GenericProcessor;
 import com.statful.client.framework.springboot.processor.MetricProcessor;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
 
+import java.util.Collections;
+import java.util.List;
+
+@Component
+@ConditionalOnProperty(name = "statful.client.springboot.processors.system.processors.enabled",
+        havingValue = "true", matchIfMissing = true)
 public class ProcessorsProcessor implements MetricProcessor {
 
     @Override
@@ -14,4 +22,10 @@ public class ProcessorsProcessor implements MetricProcessor {
         return GenericProcessor.process(SYSTEM_METRICS_PREFIX + exportedMetric.getName(),
                 MetricType.GAUGE, exportedMetric.getValue().doubleValue(), exportedMetric.getTimestamp().getTime());
     }
+
+    @Override
+    public List<String> getProcessorKeys() {
+        return Collections.singletonList("processors");
+    }
+
 }

--- a/src/main/java/com/statful/client/framework/springboot/processor/processors/system/SystemLoadProcessor.java
+++ b/src/main/java/com/statful/client/framework/springboot/processor/processors/system/SystemLoadProcessor.java
@@ -7,7 +7,15 @@ import com.statful.client.framework.springboot.common.ExportedMetric;
 import com.statful.client.framework.springboot.common.MetricType;
 import com.statful.client.framework.springboot.common.ProcessedMetric;
 import com.statful.client.framework.springboot.processor.MetricProcessor;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
 
+import java.util.Collections;
+import java.util.List;
+
+@Component
+@ConditionalOnProperty(name = "statful.client.springboot.processors.system.systemload.enabled",
+        havingValue = "true", matchIfMissing = true)
 public class SystemLoadProcessor implements MetricProcessor {
 
     @Override
@@ -25,5 +33,10 @@ public class SystemLoadProcessor implements MetricProcessor {
                 .withTimestamp(exportedMetric.getTimestamp().getTime())
                 .aggregatedBy(new AggregationDetails(Aggregation.AVG, AggregationFrequency.FREQ_60))
                 .build();
+    }
+
+    @Override
+    public List<String> getProcessorKeys() {
+        return Collections.singletonList("systemload");
     }
 }

--- a/src/main/java/com/statful/client/framework/springboot/processor/processors/system/SystemLoadProcessor.java
+++ b/src/main/java/com/statful/client/framework/springboot/processor/processors/system/SystemLoadProcessor.java
@@ -1,8 +1,7 @@
 package com.statful.client.framework.springboot.processor.processors.system;
 
 import com.statful.client.domain.api.Aggregation;
-import com.statful.client.domain.api.AggregationFreq;
-import com.statful.client.domain.api.Tags;
+import com.statful.client.domain.api.AggregationFrequency;
 import com.statful.client.framework.springboot.common.AggregationDetails;
 import com.statful.client.framework.springboot.common.ExportedMetric;
 import com.statful.client.framework.springboot.common.MetricType;
@@ -16,11 +15,15 @@ public class SystemLoadProcessor implements MetricProcessor {
         // Example: systemload.average=1.11765
         String[] metricSplit = exportedMetric.getName().split("\\.");
 
+        if (metricSplit.length != 2) {
+            throw new IllegalArgumentException();
+        }
+
         return new ProcessedMetric.Builder().withName(SYSTEM_METRICS_PREFIX + metricSplit[0])
                 .withMetricType(MetricType.GAUGE)
                 .withValue(exportedMetric.getValue().doubleValue())
                 .withTimestamp(exportedMetric.getTimestamp().getTime())
-                .aggregatedBy(new AggregationDetails(Aggregation.AVG, AggregationFreq.FREQ_60))
+                .aggregatedBy(new AggregationDetails(Aggregation.AVG, AggregationFrequency.FREQ_60))
                 .build();
     }
 }

--- a/src/main/java/com/statful/client/framework/springboot/processor/processors/system/SystemLoadProcessor.java
+++ b/src/main/java/com/statful/client/framework/springboot/processor/processors/system/SystemLoadProcessor.java
@@ -13,6 +13,12 @@ import org.springframework.stereotype.Component;
 import java.util.Collections;
 import java.util.List;
 
+/**
+ * Processor responsible for parsing exported systemload metrics.
+ *
+ * Example:
+ *  systemload.average=1.11765
+ */
 @Component
 @ConditionalOnProperty(name = "statful.client.springboot.processors.system.systemload.enabled",
         havingValue = "true", matchIfMissing = true)
@@ -20,7 +26,6 @@ public class SystemLoadProcessor implements MetricProcessor {
 
     @Override
     public ProcessedMetric process(ExportedMetric exportedMetric) {
-        // Example: systemload.average=1.11765
         String[] metricSplit = exportedMetric.getName().split("\\.");
 
         if (metricSplit.length != 2) {

--- a/src/main/java/com/statful/client/framework/springboot/processor/processors/system/SystemLoadProcessor.java
+++ b/src/main/java/com/statful/client/framework/springboot/processor/processors/system/SystemLoadProcessor.java
@@ -1,0 +1,26 @@
+package com.statful.client.framework.springboot.processor.processors.system;
+
+import com.statful.client.domain.api.Aggregation;
+import com.statful.client.domain.api.AggregationFreq;
+import com.statful.client.domain.api.Tags;
+import com.statful.client.framework.springboot.common.AggregationDetails;
+import com.statful.client.framework.springboot.common.ExportedMetric;
+import com.statful.client.framework.springboot.common.MetricType;
+import com.statful.client.framework.springboot.common.ProcessedMetric;
+import com.statful.client.framework.springboot.processor.MetricProcessor;
+
+public class SystemLoadProcessor implements MetricProcessor {
+
+    @Override
+    public ProcessedMetric process(ExportedMetric exportedMetric) {
+        // Example: systemload.average=1.11765
+        String[] metricSplit = exportedMetric.getName().split("\\.");
+
+        return new ProcessedMetric.Builder().withName(SYSTEM_METRICS_PREFIX + metricSplit[0])
+                .withMetricType(MetricType.GAUGE)
+                .withValue(exportedMetric.getValue().doubleValue())
+                .withTimestamp(exportedMetric.getTimestamp().getTime())
+                .aggregatedBy(new AggregationDetails(Aggregation.AVG, AggregationFreq.FREQ_60))
+                .build();
+    }
+}

--- a/src/main/java/com/statful/client/framework/springboot/processor/processors/system/ThreadsProcessor.java
+++ b/src/main/java/com/statful/client/framework/springboot/processor/processors/system/ThreadsProcessor.java
@@ -5,7 +5,15 @@ import com.statful.client.framework.springboot.common.ExportedMetric;
 import com.statful.client.framework.springboot.common.MetricType;
 import com.statful.client.framework.springboot.common.ProcessedMetric;
 import com.statful.client.framework.springboot.processor.MetricProcessor;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
 
+import java.util.Collections;
+import java.util.List;
+
+@Component
+@ConditionalOnProperty(name = "statful.client.springboot.processors.system.threads.enabled",
+        havingValue = "true", matchIfMissing = true)
 public class ThreadsProcessor implements MetricProcessor {
 
     private static final Tags TOTAL_TYPE_TAGS = Tags.from("type", "total");
@@ -40,5 +48,10 @@ public class ThreadsProcessor implements MetricProcessor {
                 .withValue(exportedMetric.getValue().doubleValue())
                 .withTimestamp(exportedMetric.getTimestamp().getTime())
                 .build();
+    }
+
+    @Override
+    public List<String> getProcessorKeys() {
+        return Collections.singletonList("threads");
     }
 }

--- a/src/main/java/com/statful/client/framework/springboot/processor/processors/system/ThreadsProcessor.java
+++ b/src/main/java/com/statful/client/framework/springboot/processor/processors/system/ThreadsProcessor.java
@@ -11,6 +11,15 @@ import org.springframework.stereotype.Component;
 import java.util.Collections;
 import java.util.List;
 
+/**
+ * Processor responsible for parsing exported threads metrics.
+ *
+ * Example:
+ *  threads.peak=15
+ *  threads.daemon=11
+ *  threads.totalStarted=18
+ *  threads=14
+ */
 @Component
 @ConditionalOnProperty(name = "statful.client.springboot.processors.system.threads.enabled",
         havingValue = "true", matchIfMissing = true)
@@ -20,13 +29,6 @@ public class ThreadsProcessor implements MetricProcessor {
 
     @Override
     public ProcessedMetric process(ExportedMetric exportedMetric) {
-        /**
-         * Example:
-         *  threads.peak=15
-         *  threads.daemon=11
-         *  threads.totalStarted=18
-         *  threads=14
-         */
         String[] metricSplit = exportedMetric.getName().split("\\.");
 
         Tags tags;

--- a/src/main/java/com/statful/client/framework/springboot/processor/processors/system/ThreadsProcessor.java
+++ b/src/main/java/com/statful/client/framework/springboot/processor/processors/system/ThreadsProcessor.java
@@ -8,6 +8,8 @@ import com.statful.client.framework.springboot.processor.MetricProcessor;
 
 public class ThreadsProcessor implements MetricProcessor {
 
+    private static final Tags TOTAL_TYPE_TAGS = Tags.from("type", "total");
+
     @Override
     public ProcessedMetric process(ExportedMetric exportedMetric) {
         /**
@@ -23,7 +25,7 @@ public class ThreadsProcessor implements MetricProcessor {
 
         switch (metricSplit.length) {
             case 1:
-                tags = Tags.from("type", "total");
+                tags = TOTAL_TYPE_TAGS;
                 break;
             case 2:
                 tags = Tags.from("type", metricSplit[1]);

--- a/src/main/java/com/statful/client/framework/springboot/processor/processors/system/ThreadsProcessor.java
+++ b/src/main/java/com/statful/client/framework/springboot/processor/processors/system/ThreadsProcessor.java
@@ -1,0 +1,42 @@
+package com.statful.client.framework.springboot.processor.processors.system;
+
+import com.statful.client.domain.api.Tags;
+import com.statful.client.framework.springboot.common.ExportedMetric;
+import com.statful.client.framework.springboot.common.MetricType;
+import com.statful.client.framework.springboot.common.ProcessedMetric;
+import com.statful.client.framework.springboot.processor.MetricProcessor;
+
+public class ThreadsProcessor implements MetricProcessor {
+
+    @Override
+    public ProcessedMetric process(ExportedMetric exportedMetric) {
+        /**
+         * Example:
+         *  threads.peak=15
+         *  threads.daemon=11
+         *  threads.totalStarted=18
+         *  threads=14
+         */
+        String[] metricSplit = exportedMetric.getName().split("\\.");
+
+        Tags tags;
+
+        switch (metricSplit.length) {
+            case 1:
+                tags = Tags.from("type", "total");
+                break;
+            case 2:
+                tags = Tags.from("type", metricSplit[1]);
+                break;
+            default:
+                throw new IllegalArgumentException();
+        }
+
+        return new ProcessedMetric.Builder().withName(SYSTEM_METRICS_PREFIX + metricSplit[0])
+                .withTags(tags)
+                .withMetricType(MetricType.GAUGE)
+                .withValue(exportedMetric.getValue().doubleValue())
+                .withTimestamp(exportedMetric.getTimestamp().getTime())
+                .build();
+    }
+}

--- a/src/main/java/com/statful/client/framework/springboot/processor/processors/system/UptimeProcessor.java
+++ b/src/main/java/com/statful/client/framework/springboot/processor/processors/system/UptimeProcessor.java
@@ -9,9 +9,6 @@ import org.springframework.beans.factory.annotation.Value;
 
 public class UptimeProcessor implements MetricProcessor {
 
-    @Value("${statful.client.springboot.metrics.units.enabled:false}")
-    private boolean unitsEnabled;
-
     @Override
     public ProcessedMetric process(ExportedMetric exportedMetric) {
         /**
@@ -31,10 +28,6 @@ public class UptimeProcessor implements MetricProcessor {
                 break;
             default:
                 throw new IllegalArgumentException();
-        }
-
-        if (unitsEnabled) {
-            tags.putTag("unit", "ms");
         }
 
         return new ProcessedMetric.Builder().withName(SYSTEM_METRICS_PREFIX + "uptime")

--- a/src/main/java/com/statful/client/framework/springboot/processor/processors/system/UptimeProcessor.java
+++ b/src/main/java/com/statful/client/framework/springboot/processor/processors/system/UptimeProcessor.java
@@ -5,7 +5,15 @@ import com.statful.client.framework.springboot.common.ExportedMetric;
 import com.statful.client.framework.springboot.common.MetricType;
 import com.statful.client.framework.springboot.common.ProcessedMetric;
 import com.statful.client.framework.springboot.processor.MetricProcessor;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
 
+import java.util.LinkedList;
+import java.util.List;
+
+@Component
+@ConditionalOnProperty(name = "statful.client.springboot.processors.system.uptime.enabled",
+        havingValue = "true", matchIfMissing = true)
 public class UptimeProcessor implements MetricProcessor {
 
     private static final String UPTIME_NAME = SYSTEM_METRICS_PREFIX + "uptime";
@@ -38,5 +46,13 @@ public class UptimeProcessor implements MetricProcessor {
                 .withValue(exportedMetric.getValue().doubleValue())
                 .withTimestamp(exportedMetric.getTimestamp().getTime())
                 .build();
+    }
+
+    @Override
+    public List<String> getProcessorKeys() {
+        List<String> keys = new LinkedList<>();
+        keys.add("instance");
+        keys.add("uptime");
+        return keys;
     }
 }

--- a/src/main/java/com/statful/client/framework/springboot/processor/processors/system/UptimeProcessor.java
+++ b/src/main/java/com/statful/client/framework/springboot/processor/processors/system/UptimeProcessor.java
@@ -11,6 +11,13 @@ import org.springframework.stereotype.Component;
 import java.util.LinkedList;
 import java.util.List;
 
+/**
+ * Processor responsible for parsing exported uptime metrics.
+ *
+ * Example:
+ *  instance.uptime=442414
+ *  uptime=44278
+ */
 @Component
 @ConditionalOnProperty(name = "statful.client.springboot.processors.system.uptime.enabled",
         havingValue = "true", matchIfMissing = true)
@@ -21,11 +28,6 @@ public class UptimeProcessor implements MetricProcessor {
 
     @Override
     public ProcessedMetric process(ExportedMetric exportedMetric) {
-        /**
-         * Example:
-         *  instance.uptime=442414
-         *  uptime=44278
-         */
         String[] metricSplit = exportedMetric.getName().split("\\.");
 
         Tags tags;

--- a/src/main/java/com/statful/client/framework/springboot/processor/processors/system/UptimeProcessor.java
+++ b/src/main/java/com/statful/client/framework/springboot/processor/processors/system/UptimeProcessor.java
@@ -5,9 +5,11 @@ import com.statful.client.framework.springboot.common.ExportedMetric;
 import com.statful.client.framework.springboot.common.MetricType;
 import com.statful.client.framework.springboot.common.ProcessedMetric;
 import com.statful.client.framework.springboot.processor.MetricProcessor;
-import org.springframework.beans.factory.annotation.Value;
 
 public class UptimeProcessor implements MetricProcessor {
+
+    private static final String UPTIME_NAME = SYSTEM_METRICS_PREFIX + "uptime";
+    private static final Tags VM_TYPE_TAGS = Tags.from("type", "vm");
 
     @Override
     public ProcessedMetric process(ExportedMetric exportedMetric) {
@@ -21,7 +23,7 @@ public class UptimeProcessor implements MetricProcessor {
         Tags tags;
         switch (metricSplit.length) {
             case 1:
-                tags = Tags.from("type", "vm");
+                tags = VM_TYPE_TAGS;
                 break;
             case 2:
                 tags = Tags.from("type", metricSplit[0]);
@@ -30,7 +32,7 @@ public class UptimeProcessor implements MetricProcessor {
                 throw new IllegalArgumentException();
         }
 
-        return new ProcessedMetric.Builder().withName(SYSTEM_METRICS_PREFIX + "uptime")
+        return new ProcessedMetric.Builder().withName(UPTIME_NAME)
                 .withTags(tags)
                 .withMetricType(MetricType.GAUGE)
                 .withValue(exportedMetric.getValue().doubleValue())

--- a/src/main/java/com/statful/client/framework/springboot/processor/processors/system/UptimeProcessor.java
+++ b/src/main/java/com/statful/client/framework/springboot/processor/processors/system/UptimeProcessor.java
@@ -1,0 +1,47 @@
+package com.statful.client.framework.springboot.processor.processors.system;
+
+import com.statful.client.domain.api.Tags;
+import com.statful.client.framework.springboot.common.ExportedMetric;
+import com.statful.client.framework.springboot.common.MetricType;
+import com.statful.client.framework.springboot.common.ProcessedMetric;
+import com.statful.client.framework.springboot.processor.MetricProcessor;
+import org.springframework.beans.factory.annotation.Value;
+
+public class UptimeProcessor implements MetricProcessor {
+
+    @Value("${statful.client.springboot.metrics.units.enabled:false}")
+    private boolean unitsEnabled;
+
+    @Override
+    public ProcessedMetric process(ExportedMetric exportedMetric) {
+        /**
+         * Example:
+         *  instance.uptime=442414
+         *  uptime=44278
+         */
+        String[] metricSplit = exportedMetric.getName().split("\\.");
+
+        Tags tags;
+        switch (metricSplit.length) {
+            case 1:
+                tags = Tags.from("type", "vm");
+                break;
+            case 2:
+                tags = Tags.from("type", metricSplit[0]);
+                break;
+            default:
+                throw new IllegalArgumentException();
+        }
+
+        if (unitsEnabled) {
+            tags.putTag("unit", "ms");
+        }
+
+        return new ProcessedMetric.Builder().withName(SYSTEM_METRICS_PREFIX + "uptime")
+                .withTags(tags)
+                .withMetricType(MetricType.GAUGE)
+                .withValue(exportedMetric.getValue().doubleValue())
+                .withTimestamp(exportedMetric.getTimestamp().getTime())
+                .build();
+    }
+}

--- a/src/main/java/com/statful/client/framework/springboot/processor/processors/tomcat/HttpSessionsProcessor.java
+++ b/src/main/java/com/statful/client/framework/springboot/processor/processors/tomcat/HttpSessionsProcessor.java
@@ -5,7 +5,15 @@ import com.statful.client.framework.springboot.common.ExportedMetric;
 import com.statful.client.framework.springboot.common.MetricType;
 import com.statful.client.framework.springboot.common.ProcessedMetric;
 import com.statful.client.framework.springboot.processor.MetricProcessor;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
 
+import java.util.Collections;
+import java.util.List;
+
+@Component
+@ConditionalOnProperty(name = "statful.client.springboot.processors.tomcat.httpSessions.enabled",
+        havingValue = "true", matchIfMissing = true)
 public class HttpSessionsProcessor implements MetricProcessor {
 
     @Override
@@ -29,5 +37,10 @@ public class HttpSessionsProcessor implements MetricProcessor {
                 .withValue(exportedMetric.getValue().doubleValue())
                 .withTimestamp(exportedMetric.getTimestamp().getTime())
                 .build();
+    }
+
+    @Override
+    public List<String> getProcessorKeys() {
+        return Collections.singletonList("httpsessions");
     }
 }

--- a/src/main/java/com/statful/client/framework/springboot/processor/processors/tomcat/HttpSessionsProcessor.java
+++ b/src/main/java/com/statful/client/framework/springboot/processor/processors/tomcat/HttpSessionsProcessor.java
@@ -1,0 +1,29 @@
+package com.statful.client.framework.springboot.processor.processors.tomcat;
+
+import com.statful.client.domain.api.Tags;
+import com.statful.client.framework.springboot.common.ExportedMetric;
+import com.statful.client.framework.springboot.common.MetricType;
+import com.statful.client.framework.springboot.common.ProcessedMetric;
+import com.statful.client.framework.springboot.processor.MetricProcessor;
+
+public class HttpSessionsProcessor implements MetricProcessor {
+
+    @Override
+    public ProcessedMetric process(ExportedMetric exportedMetric) {
+        /**
+         * Example:
+         *  httpsessions.max=-1
+         *  httpsessions.active=5
+         */
+        String[] metricSplit = exportedMetric.getName().split("\\.");
+
+        Tags tags = Tags.from("type", metricSplit[1]);
+
+        return new ProcessedMetric.Builder().withName(TOMCAT_METRICS_PREFIX + metricSplit[0])
+                .withTags(tags)
+                .withMetricType(MetricType.GAUGE)
+                .withValue(exportedMetric.getValue().doubleValue())
+                .withTimestamp(exportedMetric.getTimestamp().getTime())
+                .build();
+    }
+}

--- a/src/main/java/com/statful/client/framework/springboot/processor/processors/tomcat/HttpSessionsProcessor.java
+++ b/src/main/java/com/statful/client/framework/springboot/processor/processors/tomcat/HttpSessionsProcessor.java
@@ -17,6 +17,10 @@ public class HttpSessionsProcessor implements MetricProcessor {
          */
         String[] metricSplit = exportedMetric.getName().split("\\.");
 
+        if (metricSplit.length != 2) {
+            throw new IllegalArgumentException();
+        }
+
         Tags tags = Tags.from("type", metricSplit[1]);
 
         return new ProcessedMetric.Builder().withName(TOMCAT_METRICS_PREFIX + metricSplit[0])

--- a/src/main/java/com/statful/client/framework/springboot/processor/processors/tomcat/HttpSessionsProcessor.java
+++ b/src/main/java/com/statful/client/framework/springboot/processor/processors/tomcat/HttpSessionsProcessor.java
@@ -11,6 +11,13 @@ import org.springframework.stereotype.Component;
 import java.util.Collections;
 import java.util.List;
 
+/**
+ * Processor responsible for parsing exported tomcat http sessions metrics.
+ *
+ * Example:
+ *  httpsessions.max=-1
+ *  httpsessions.active=5
+ */
 @Component
 @ConditionalOnProperty(name = "statful.client.springboot.processors.tomcat.httpSessions.enabled",
         havingValue = "true", matchIfMissing = true)
@@ -18,11 +25,6 @@ public class HttpSessionsProcessor implements MetricProcessor {
 
     @Override
     public ProcessedMetric process(ExportedMetric exportedMetric) {
-        /**
-         * Example:
-         *  httpsessions.max=-1
-         *  httpsessions.active=5
-         */
         String[] metricSplit = exportedMetric.getName().split("\\.");
 
         if (metricSplit.length != 2) {

--- a/src/main/java/com/statful/client/framework/springboot/proxy/StatfulClientProxy.java
+++ b/src/main/java/com/statful/client/framework/springboot/proxy/StatfulClientProxy.java
@@ -8,8 +8,6 @@ import com.statful.client.framework.springboot.common.MetricType;
 import com.statful.client.framework.springboot.common.ProcessedMetric;
 import com.statful.client.framework.springboot.config.SpringbootClientConfiguration;
 import com.statful.client.framework.springboot.processor.StatfulMetricProcessor;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.actuate.metrics.Metric;
 import org.springframework.boot.actuate.metrics.writer.Delta;
@@ -25,8 +23,6 @@ import java.util.Optional;
 @Component
 @ConditionalOnBean(value = StatfulClient.class)
 public class StatfulClientProxy {
-
-    private static final Log logger = LogFactory.getLog(StatfulClientProxy.class);
 
     @Resource
     private SpringbootClientConfiguration springbootClientConfiguration;

--- a/src/main/java/com/statful/client/framework/springboot/proxy/StatfulClientProxy.java
+++ b/src/main/java/com/statful/client/framework/springboot/proxy/StatfulClientProxy.java
@@ -1,0 +1,117 @@
+package com.statful.client.framework.springboot.proxy;
+
+import com.statful.client.domain.api.Aggregations;
+import com.statful.client.domain.api.StatfulClient;
+import com.statful.client.domain.api.Tags;
+import com.statful.client.framework.springboot.common.ExportedMetric;
+import com.statful.client.framework.springboot.common.MetricType;
+import com.statful.client.framework.springboot.common.ProcessedMetric;
+import com.statful.client.framework.springboot.config.SpringbootClientConfiguration;
+import com.statful.client.framework.springboot.processor.StatfulMetricProcessor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.actuate.metrics.Metric;
+import org.springframework.boot.actuate.metrics.writer.Delta;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.stereotype.Component;
+
+import javax.annotation.Resource;
+import java.util.Optional;
+
+/**
+ * Class to proxy metrics into a {@link StatfulClient} implementation on the springboot client context.
+ */
+@Component
+@ConditionalOnBean(value = StatfulClient.class)
+public class StatfulClientProxy {
+
+    @Resource
+    private SpringbootClientConfiguration springbootClientConfiguration;
+
+    @Resource
+    private StatfulClient statfulClient;
+
+    @Value("${statful.client.springboot.metrics.prefix:springboot}")
+    private String metricsPrefix;
+
+    @Value("${statful.client.springboot.metrics.namespace:#{null}}")
+    private String metricsNamespace;
+
+    /**
+     * Ingest a raw {@link Metric}.
+     *
+     * @param metric Raw {@link Metric} exported by springboot
+     */
+    public void ingestMetric(Metric<?> metric) {
+        ExportedMetric exportedMetric = new ExportedMetric.Builder()
+                .withName(metric.getName())
+                .withValue(metric.getValue())
+                .withTimestamp(metric.getTimestamp())
+                .build();
+
+        ingest(exportedMetric);
+    }
+
+    /**
+     * Ingest a raw {@link Delta}.
+     *
+     * @param delta Raw {@link Delta} exported by springboot
+     */
+    public void ingestMetric(Delta<?> delta) {
+        ExportedMetric exportedMetric = new ExportedMetric.Builder()
+                .withName(delta.getName())
+                .withValue(delta.getValue())
+                .withTimestamp(delta.getTimestamp())
+                .build();
+
+        ingest(exportedMetric);
+    }
+
+    private void ingest(ExportedMetric exportedMetric) {
+        if (StatfulMetricProcessor.validate(exportedMetric)) {
+            ProcessedMetric processedMetric = StatfulMetricProcessor.process(exportedMetric);
+
+            if (processedMetric.getAggregationDetails().isPresent()) {
+                putMetricAggregated(processedMetric);
+            } else {
+                putMetric(processedMetric);
+            }
+        }
+    }
+
+    private void putMetricAggregated(ProcessedMetric processedMetric) {
+        statfulClient.putAggregated(buildMetricName(processedMetric.getMetricType(), processedMetric.getName()),
+                processedMetric.getValue().toString(), mergeDefaultTags(processedMetric.getTags()),
+                processedMetric.getAggregationDetails().get().getAggregation(),
+                processedMetric.getAggregationDetails().get().getAggregationFreq(), 100, metricsNamespace,
+                processedMetric.getTimestamp());
+    }
+
+    private void putMetric(ProcessedMetric processedMetric) {
+        statfulClient.put(buildMetricName(processedMetric.getMetricType(), processedMetric.getName()),
+                processedMetric.getValue().toString(), mergeDefaultTags(processedMetric.getTags()),
+                getOrDefaultAggregations(processedMetric.getAggregations()), null, 100, metricsNamespace,
+                processedMetric.getTimestamp());
+    }
+
+    private Tags mergeDefaultTags(Optional<Tags> tags) {
+        Tags mergedTags = new Tags();
+        if (tags.isPresent()) {
+            mergedTags = tags.get();
+        }
+
+        Tags customTags = new Tags();
+        springbootClientConfiguration.getMetrics().getTags().forEach(tag ->
+                customTags.putTag(tag.getName(), tag.getValue()));
+
+        return mergedTags.merge(customTags);
+    }
+
+    private Aggregations getOrDefaultAggregations(Optional<Aggregations> aggregations) {
+        return aggregations.isPresent() ? aggregations.get() : null;
+    }
+
+    private String buildMetricName(MetricType metricType, String metricName) {
+        return metricsPrefix.replaceAll("\\.$", "") + "." + metricType.name().toLowerCase() + "." + metricName;
+    }
+}

--- a/src/main/java/com/statful/client/framework/springboot/writer/StatfulMetricWriter.java
+++ b/src/main/java/com/statful/client/framework/springboot/writer/StatfulMetricWriter.java
@@ -35,6 +35,10 @@ public class StatfulMetricWriter implements MetricWriter {
     public void set(Metric<?> metric) {
         statfulClientProxy.ingestMetric(metric);
     }
+
+    public void setStatfulClientProxy(StatfulClientProxy statfulClientProxy) {
+        this.statfulClientProxy = statfulClientProxy;
+    }
 }
 
 

--- a/src/main/java/com/statful/client/framework/springboot/writer/StatfulMetricWriter.java
+++ b/src/main/java/com/statful/client/framework/springboot/writer/StatfulMetricWriter.java
@@ -14,13 +14,13 @@ import javax.annotation.Resource;
  */
 public class StatfulMetricWriter implements MetricWriter {
 
-    private static final Log logger = LogFactory.getLog(StatfulMetricWriter.class);
+    private static final Log LOGGER = LogFactory.getLog(StatfulMetricWriter.class);
 
     @Resource
     StatfulClientProxy statfulClientProxy;
 
     public StatfulMetricWriter() {
-        logger.info("Initializing StatfulMetricWriter");
+        LOGGER.info("Initializing StatfulMetricWriter");
     }
 
     @Override
@@ -29,7 +29,9 @@ public class StatfulMetricWriter implements MetricWriter {
     }
 
     @Override
-    public void reset(String s) {}
+    public void reset(String s) {
+        LOGGER.debug("MetricWriter reset method is not implemented");
+    }
 
     @Override
     public void set(Metric<?> metric) {

--- a/src/main/java/com/statful/client/framework/springboot/writer/StatfulMetricWriter.java
+++ b/src/main/java/com/statful/client/framework/springboot/writer/StatfulMetricWriter.java
@@ -1,0 +1,40 @@
+package com.statful.client.framework.springboot.writer;
+
+import com.statful.client.framework.springboot.proxy.StatfulClientProxy;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.springframework.boot.actuate.metrics.Metric;
+import org.springframework.boot.actuate.metrics.writer.Delta;
+import org.springframework.boot.actuate.metrics.writer.MetricWriter;
+
+import javax.annotation.Resource;
+
+/**
+ * {@link MetricWriter} implementation for Statful.
+ */
+public class StatfulMetricWriter implements MetricWriter {
+
+    private static final Log logger = LogFactory.getLog(StatfulMetricWriter.class);
+
+    @Resource
+    StatfulClientProxy statfulClientProxy;
+
+    public StatfulMetricWriter() {
+        logger.info("Initializing StatfulMetricWriter");
+    }
+
+    @Override
+    public void increment(Delta<?> delta) {
+        statfulClientProxy.ingestMetric(delta);
+    }
+
+    @Override
+    public void reset(String s) {}
+
+    @Override
+    public void set(Metric<?> metric) {
+        statfulClientProxy.ingestMetric(metric);
+    }
+}
+
+

--- a/src/test/java/com/statful/client/framework/springboot/processor/GenericProcessorTest.java
+++ b/src/test/java/com/statful/client/framework/springboot/processor/GenericProcessorTest.java
@@ -1,0 +1,32 @@
+package com.statful.client.framework.springboot.processor;
+
+import com.statful.client.framework.springboot.common.MetricType;
+import com.statful.client.framework.springboot.common.ProcessedMetric;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+public class GenericProcessorTest {
+
+    @Test
+    public void shouldProcessMetric() {
+        // Given
+        String name = "foo";
+        MetricType type = MetricType.COUNTER;
+        Double value = 1D;
+        long timestamp = 123456789L;
+
+        // When
+        ProcessedMetric processedMetric = GenericProcessor.process(name, type, value, timestamp);
+
+        // Then
+        assertEquals(name, processedMetric.getName());
+        assertEquals(type, processedMetric.getMetricType());
+        assertEquals(value, processedMetric.getValue());
+        assertEquals(timestamp, processedMetric.getTimestamp());
+        assertFalse(processedMetric.getAggregations().isPresent());
+        assertFalse(processedMetric.getTags().isPresent());
+        assertFalse(processedMetric.getAggregationDetails().isPresent());
+    }
+}

--- a/src/test/java/com/statful/client/framework/springboot/processor/ProcessorMapTest.java
+++ b/src/test/java/com/statful/client/framework/springboot/processor/ProcessorMapTest.java
@@ -1,11 +1,26 @@
 package com.statful.client.framework.springboot.processor;
 
-import com.statful.client.framework.springboot.processor.processors.system.GcProcessor;
+import com.statful.client.framework.springboot.processor.processors.http.HttpRequestsProcessor;
+import com.statful.client.framework.springboot.processor.processors.system.*;
+import com.statful.client.framework.springboot.processor.processors.tomcat.HttpSessionsProcessor;
+import org.junit.Before;
 import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 
 import static org.junit.Assert.*;
 
 public class ProcessorMapTest {
+
+    private ProcessorMap subject;
+
+    @Before
+    public void before() {
+        subject = new ProcessorMap();
+        subject.setProcessors(Collections.singletonList(new GcProcessor()));
+    }
 
     @Test
     public void shouldValidateProcessor() {
@@ -13,7 +28,7 @@ public class ProcessorMapTest {
         String metric = "gc";
 
         // When
-        boolean validated = ProcessorMap.validateProcessor(metric);
+        boolean validated = subject.validateProcessor(metric);
 
         // Then
         assertTrue(validated);
@@ -25,7 +40,7 @@ public class ProcessorMapTest {
         String metric = "invalid";
 
         // When
-        boolean validated = ProcessorMap.validateProcessor(metric);
+        boolean validated = subject.validateProcessor(metric);
 
         // Then
         assertFalse(validated);
@@ -37,10 +52,36 @@ public class ProcessorMapTest {
         String metric = "gc";
 
         // When
-        MetricProcessor metricProcessor = ProcessorMap.getProcessor(metric);
+        MetricProcessor metricProcessor = subject.getProcessor(metric);
 
         // Then
         assertEquals(GcProcessor.class, metricProcessor.getClass());
+    }
+
+    @Test
+    public void shouldSetMultipleProcessors() {
+        // Given
+        List<MetricProcessor> metricProcessors = new ArrayList<>();
+        metricProcessors.add(new HttpRequestsProcessor());
+        metricProcessors.add(new ClassesProcessor());
+        metricProcessors.add(new GcProcessor());
+        metricProcessors.add(new HeapProcessor());
+        metricProcessors.add(new MemProcessor());
+        metricProcessors.add(new ProcessorsProcessor());
+        metricProcessors.add(new SystemLoadProcessor());
+        metricProcessors.add(new ThreadsProcessor());
+        metricProcessors.add(new UptimeProcessor());
+        metricProcessors.add(new HttpSessionsProcessor());
+
+        // When
+        subject.setProcessors(metricProcessors);
+
+        // Then
+        assertEquals("Number of mappers should be expected", 13, subject.getProcessors().size());
+        assertEquals(HttpRequestsProcessor.class, subject.getProcessors().get("counter.status").getClass());
+        assertEquals(HttpRequestsProcessor.class, subject.getProcessors().get("gauge.response").getClass());
+        assertEquals(GcProcessor.class, subject.getProcessors().get("gc").getClass());
+
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -49,6 +90,7 @@ public class ProcessorMapTest {
         String metric = "invalid";
 
         // When
-        ProcessorMap.getProcessor(metric);
+        subject.getProcessor(metric);
     }
+
 }

--- a/src/test/java/com/statful/client/framework/springboot/processor/ProcessorMapTest.java
+++ b/src/test/java/com/statful/client/framework/springboot/processor/ProcessorMapTest.java
@@ -1,0 +1,54 @@
+package com.statful.client.framework.springboot.processor;
+
+import com.statful.client.framework.springboot.processor.processors.system.GcProcessor;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class ProcessorMapTest {
+
+    @Test
+    public void shouldValidateProcessor() {
+        // Given
+        String metric = "gc";
+
+        // When
+        boolean validated = ProcessorMap.validateProcessor(metric);
+
+        // Then
+        assertTrue(validated);
+    }
+
+    @Test
+    public void shouldNotValidateProcessorIfInvalidMetric() {
+        // Given
+        String metric = "invalid";
+
+        // When
+        boolean validated = ProcessorMap.validateProcessor(metric);
+
+        // Then
+        assertFalse(validated);
+    }
+
+    @Test
+    public void shouldReturnProperProcessor() {
+        // Given
+        String metric = "gc";
+
+        // When
+        MetricProcessor metricProcessor = ProcessorMap.getProcessor(metric);
+
+        // Then
+        assertEquals(GcProcessor.class, metricProcessor.getClass());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldThrowIllegalArgumentExceptionIfInvalidMetric() {
+        // Given
+        String metric = "invalid";
+
+        // When
+        ProcessorMap.getProcessor(metric);
+    }
+}

--- a/src/test/java/com/statful/client/framework/springboot/processor/StatfulMetricProcessorTest.java
+++ b/src/test/java/com/statful/client/framework/springboot/processor/StatfulMetricProcessorTest.java
@@ -1,0 +1,69 @@
+package com.statful.client.framework.springboot.processor;
+
+import com.statful.client.framework.springboot.common.ExportedMetric;
+import com.statful.client.framework.springboot.common.MetricType;
+import com.statful.client.framework.springboot.common.ProcessedMetric;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.time.Instant;
+import java.util.Date;
+
+import static com.statful.client.framework.springboot.processor.MetricProcessor.ACCUMULATED_METRICS_PREFIX;
+import static com.statful.client.framework.springboot.processor.MetricProcessor.SYSTEM_METRICS_PREFIX;
+import static org.junit.Assert.*;
+
+public class StatfulMetricProcessorTest {
+
+    private static ExportedMetric exportedMetric;
+    private StatfulMetricProcessor subject;
+
+    @Before
+    public void before() {
+        subject = new StatfulMetricProcessor();
+        exportedMetric = new ExportedMetric.Builder()
+                .withName("gc.ps_scavenge.count")
+                .withValue(1D)
+                .withTimestamp(Date.from(Instant.EPOCH))
+                .build();
+    }
+
+    @Test
+    public void shouldValidateProcessor() {
+        // When
+        boolean validated = subject.validate(exportedMetric);
+
+        // Then
+        assertTrue(validated);
+    }
+
+    @Test
+    public void shouldNotValidateProcessorIfInvalidMetric() {
+        // Given
+        ExportedMetric exportedMetric = new ExportedMetric.Builder()
+                .withName("invalid")
+                .build();
+
+        // When
+        boolean validated = subject.validate(exportedMetric);
+
+        // Then
+        assertFalse(validated);
+    }
+
+    @Test
+    public void shouldReturnProperProcessor() {
+        // When
+        ProcessedMetric processedMetric = subject.process(exportedMetric);
+
+        // Then
+        assertEquals(SYSTEM_METRICS_PREFIX + ACCUMULATED_METRICS_PREFIX + "gc", processedMetric.getName());
+        assertEquals(MetricType.COUNTER, processedMetric.getMetricType());
+        assertEquals(Double.valueOf(1D), processedMetric.getValue());
+        assertEquals(Instant.EPOCH.toEpochMilli(), processedMetric.getTimestamp());
+        assertEquals("ps_scavenge", processedMetric.getTags().get().getTagValue("name"));
+        assertFalse(processedMetric.getAggregations().isPresent());
+        assertFalse(processedMetric.getAggregationDetails().isPresent());
+    }
+
+}

--- a/src/test/java/com/statful/client/framework/springboot/processor/StatfulMetricProcessorTest.java
+++ b/src/test/java/com/statful/client/framework/springboot/processor/StatfulMetricProcessorTest.java
@@ -3,8 +3,10 @@ package com.statful.client.framework.springboot.processor;
 import com.statful.client.framework.springboot.common.ExportedMetric;
 import com.statful.client.framework.springboot.common.MetricType;
 import com.statful.client.framework.springboot.common.ProcessedMetric;
+import com.statful.client.framework.springboot.processor.processors.system.GcProcessor;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mock;
 
 import java.time.Instant;
 import java.util.Date;
@@ -12,17 +14,33 @@ import java.util.Date;
 import static com.statful.client.framework.springboot.processor.MetricProcessor.ACCUMULATED_METRICS_PREFIX;
 import static com.statful.client.framework.springboot.processor.MetricProcessor.SYSTEM_METRICS_PREFIX;
 import static org.junit.Assert.*;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.initMocks;
 
 public class StatfulMetricProcessorTest {
 
-    private static ExportedMetric exportedMetric;
+    private static final String GC_PS_SCAVENGE_COUNT = "gc.ps_scavenge.count";
+    private static final String INVALID = "invalid";
+    private static ExportedMetric EXPORTED_METRIC;
+
+    @Mock
+    private ProcessorMap processorMap;
+
     private StatfulMetricProcessor subject;
 
     @Before
     public void before() {
+        initMocks(this);
+
+        when(processorMap.validateProcessor(GC_PS_SCAVENGE_COUNT)).thenReturn(true);
+        when(processorMap.validateProcessor(INVALID)).thenReturn(false);
+        when(processorMap.getProcessor(GC_PS_SCAVENGE_COUNT)).thenReturn(new GcProcessor());
+
         subject = new StatfulMetricProcessor();
-        exportedMetric = new ExportedMetric.Builder()
-                .withName("gc.ps_scavenge.count")
+        subject.setProcessorMap(processorMap);
+
+        EXPORTED_METRIC = new ExportedMetric.Builder()
+                .withName(GC_PS_SCAVENGE_COUNT)
                 .withValue(1D)
                 .withTimestamp(Date.from(Instant.EPOCH))
                 .build();
@@ -31,7 +49,7 @@ public class StatfulMetricProcessorTest {
     @Test
     public void shouldValidateProcessor() {
         // When
-        boolean validated = subject.validate(exportedMetric);
+        boolean validated = subject.validate(EXPORTED_METRIC);
 
         // Then
         assertTrue(validated);
@@ -41,7 +59,7 @@ public class StatfulMetricProcessorTest {
     public void shouldNotValidateProcessorIfInvalidMetric() {
         // Given
         ExportedMetric exportedMetric = new ExportedMetric.Builder()
-                .withName("invalid")
+                .withName(INVALID)
                 .build();
 
         // When
@@ -54,7 +72,7 @@ public class StatfulMetricProcessorTest {
     @Test
     public void shouldReturnProperProcessor() {
         // When
-        ProcessedMetric processedMetric = subject.process(exportedMetric);
+        ProcessedMetric processedMetric = subject.process(EXPORTED_METRIC);
 
         // Then
         assertEquals(SYSTEM_METRICS_PREFIX + ACCUMULATED_METRICS_PREFIX + "gc", processedMetric.getName());

--- a/src/test/java/com/statful/client/framework/springboot/processor/processors/http/HttpRequestProcessorTest.java
+++ b/src/test/java/com/statful/client/framework/springboot/processor/processors/http/HttpRequestProcessorTest.java
@@ -1,0 +1,81 @@
+package com.statful.client.framework.springboot.processor.processors.http;
+
+import com.statful.client.framework.springboot.common.ExportedMetric;
+import com.statful.client.framework.springboot.common.MetricType;
+import com.statful.client.framework.springboot.common.ProcessedMetric;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.time.Instant;
+import java.util.Date;
+
+import static com.statful.client.framework.springboot.processor.MetricProcessor.ACCUMULATED_METRICS_PREFIX;
+import static com.statful.client.framework.springboot.processor.MetricProcessor.LATEST_METRICS_PREFIX;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+public class HttpRequestProcessorTest {
+
+    private HttpRequestsProcessor subject;
+
+    @Before
+    public void before() {
+        subject = new HttpRequestsProcessor();
+    }
+
+    @Test
+    public void shouldProcessMetricCounter() {
+        // Given
+        ExportedMetric exportedMetric = new ExportedMetric.Builder()
+                .withName("counter.status.200.star-star.favicon.ico")
+                .withTimestamp(Date.from(Instant.EPOCH))
+                .withValue(1D)
+                .build();
+
+        // When
+        ProcessedMetric processedMetric = subject.process(exportedMetric);
+
+        // Then
+        assertEquals(ACCUMULATED_METRICS_PREFIX + "requests", processedMetric.getName());
+        assertEquals(MetricType.COUNTER, processedMetric.getMetricType());
+        assertEquals(Double.valueOf(1D), processedMetric.getValue());
+        assertEquals(Instant.EPOCH.toEpochMilli(), processedMetric.getTimestamp());
+        assertEquals("200", processedMetric.getTags().get().getTagValue("status"));
+        assertEquals("star-star.favicon.ico", processedMetric.getTags().get().getTagValue("url"));
+        assertFalse(processedMetric.getAggregations().isPresent());
+        assertFalse(processedMetric.getAggregationDetails().isPresent());
+    }
+
+    @Test
+    public void shouldProcessMetricGauge() {
+        // Given
+        ExportedMetric exportedMetric = new ExportedMetric.Builder()
+                .withName("gauge.response.star-star.favicon.ico")
+                .withTimestamp(Date.from(Instant.EPOCH))
+                .withValue(1D)
+                .build();
+
+        // When
+        ProcessedMetric processedMetric = subject.process(exportedMetric);
+
+        // Then
+        assertEquals(LATEST_METRICS_PREFIX + "responses", processedMetric.getName());
+        assertEquals(MetricType.TIMER, processedMetric.getMetricType());
+        assertEquals(Double.valueOf(1D), processedMetric.getValue());
+        assertEquals(Instant.EPOCH.toEpochMilli(), processedMetric.getTimestamp());
+        assertEquals("star-star.favicon.ico", processedMetric.getTags().get().getTagValue("url"));
+        assertFalse(processedMetric.getAggregations().isPresent());
+        assertFalse(processedMetric.getAggregationDetails().isPresent());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldThrowIllegalArgumentExceptionIfInvalidMetric() {
+        // Given
+        ExportedMetric exportedMetric = new ExportedMetric.Builder()
+                .withName("this.is.an.invalid.metric.for.sure")
+                .build();
+
+        // When
+        subject.process(exportedMetric);
+    }
+}

--- a/src/test/java/com/statful/client/framework/springboot/processor/processors/system/ClassesProcessorTest.java
+++ b/src/test/java/com/statful/client/framework/springboot/processor/processors/system/ClassesProcessorTest.java
@@ -1,0 +1,79 @@
+package com.statful.client.framework.springboot.processor.processors.system;
+
+import com.statful.client.framework.springboot.common.ExportedMetric;
+import com.statful.client.framework.springboot.common.MetricType;
+import com.statful.client.framework.springboot.common.ProcessedMetric;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.time.Instant;
+import java.util.Date;
+
+import static com.statful.client.framework.springboot.processor.MetricProcessor.SYSTEM_METRICS_PREFIX;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+public class ClassesProcessorTest {
+
+    private ClassesProcessor subject;
+
+    @Before
+    public void before() {
+        subject = new ClassesProcessor();
+    }
+
+    @Test
+    public void shouldProcessMetricWithoutType() {
+        // Given
+        ExportedMetric exportedMetric = new ExportedMetric.Builder()
+                .withName("classes")
+                .withTimestamp(Date.from(Instant.EPOCH))
+                .withValue(1D)
+                .build();
+
+        // When
+        ProcessedMetric processedMetric = subject.process(exportedMetric);
+
+        // Then
+        assertEquals(SYSTEM_METRICS_PREFIX + "classes", processedMetric.getName());
+        assertEquals(MetricType.GAUGE, processedMetric.getMetricType());
+        assertEquals(Double.valueOf(1D), processedMetric.getValue());
+        assertEquals(Instant.EPOCH.toEpochMilli(), processedMetric.getTimestamp());
+        assertEquals("total", processedMetric.getTags().get().getTagValue("type"));
+        assertFalse(processedMetric.getAggregations().isPresent());
+        assertFalse(processedMetric.getAggregationDetails().isPresent());
+    }
+
+    @Test
+    public void shouldProcessMetricWithType() {
+        // Given
+        ExportedMetric exportedMetric = new ExportedMetric.Builder()
+                .withName("classes.loaded")
+                .withTimestamp(Date.from(Instant.EPOCH))
+                .withValue(1D)
+                .build();
+
+        // When
+        ProcessedMetric processedMetric = subject.process(exportedMetric);
+
+        // Then
+        assertEquals(SYSTEM_METRICS_PREFIX + "classes", processedMetric.getName());
+        assertEquals(MetricType.GAUGE, processedMetric.getMetricType());
+        assertEquals(Double.valueOf(1D), processedMetric.getValue());
+        assertEquals(Instant.EPOCH.toEpochMilli(), processedMetric.getTimestamp());
+        assertEquals("loaded", processedMetric.getTags().get().getTagValue("type"));
+        assertFalse(processedMetric.getAggregations().isPresent());
+        assertFalse(processedMetric.getAggregationDetails().isPresent());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldThrowIllegalArgumentExceptionIfInvalidMetric() {
+        // Given
+        ExportedMetric exportedMetric = new ExportedMetric.Builder()
+                .withName("this.is.an.invalid.metric.for.sure")
+                .build();
+
+        // When
+        subject.process(exportedMetric);
+    }
+}

--- a/src/test/java/com/statful/client/framework/springboot/processor/processors/system/GcProcessorTest.java
+++ b/src/test/java/com/statful/client/framework/springboot/processor/processors/system/GcProcessorTest.java
@@ -1,0 +1,91 @@
+package com.statful.client.framework.springboot.processor.processors.system;
+
+import com.statful.client.framework.springboot.common.ExportedMetric;
+import com.statful.client.framework.springboot.common.MetricType;
+import com.statful.client.framework.springboot.common.ProcessedMetric;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.time.Instant;
+import java.util.Date;
+
+import static com.statful.client.framework.springboot.processor.MetricProcessor.ACCUMULATED_METRICS_PREFIX;
+import static com.statful.client.framework.springboot.processor.MetricProcessor.SYSTEM_METRICS_PREFIX;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+public class GcProcessorTest {
+
+    private GcProcessor subject;
+
+    @Before
+    public void before() {
+        subject = new GcProcessor();
+    }
+
+    @Test
+    public void shouldProcessMetricCount() {
+        // Given
+        ExportedMetric exportedMetric = new ExportedMetric.Builder()
+                .withName("gc.ps_scavenge.count")
+                .withTimestamp(Date.from(Instant.EPOCH))
+                .withValue(1D)
+                .build();
+
+        // When
+        ProcessedMetric processedMetric = subject.process(exportedMetric);
+
+        // Then
+        assertEquals(SYSTEM_METRICS_PREFIX + ACCUMULATED_METRICS_PREFIX + "gc", processedMetric.getName());
+        assertEquals(MetricType.COUNTER, processedMetric.getMetricType());
+        assertEquals(Double.valueOf(1D), processedMetric.getValue());
+        assertEquals(Instant.EPOCH.toEpochMilli(), processedMetric.getTimestamp());
+        assertEquals("ps_scavenge", processedMetric.getTags().get().getTagValue("name"));
+        assertFalse(processedMetric.getAggregations().isPresent());
+        assertFalse(processedMetric.getAggregationDetails().isPresent());
+    }
+
+    @Test
+    public void shouldProcessMetricGauge() {
+        // Given
+        ExportedMetric exportedMetric = new ExportedMetric.Builder()
+                .withName("gc.ps_scavenge.time")
+                .withTimestamp(Date.from(Instant.EPOCH))
+                .withValue(1D)
+                .build();
+
+        // When
+        ProcessedMetric processedMetric = subject.process(exportedMetric);
+
+        // Then
+        assertEquals(SYSTEM_METRICS_PREFIX + ACCUMULATED_METRICS_PREFIX + "gc", processedMetric.getName());
+        assertEquals(MetricType.TIMER, processedMetric.getMetricType());
+        assertEquals(Double.valueOf(1D), processedMetric.getValue());
+        assertEquals(Instant.EPOCH.toEpochMilli(), processedMetric.getTimestamp());
+        assertEquals("ps_scavenge", processedMetric.getTags().get().getTagValue("name"));
+        assertFalse(processedMetric.getAggregations().isPresent());
+        assertFalse(processedMetric.getAggregationDetails().isPresent());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldThrowIllegalArgumentExceptionIfInvalidMetricDueToTooManyParts() {
+        // Given
+        ExportedMetric exportedMetric = new ExportedMetric.Builder()
+                .withName("this.is.an.invalid.metric.for.sure")
+                .build();
+
+        // When
+        subject.process(exportedMetric);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldThrowIllegalArgumentExceptionIfInvalidMetricDueToUnknownName() {
+        // Given
+        ExportedMetric exportedMetric = new ExportedMetric.Builder()
+                .withName("gc.invalid.name")
+                .build();
+
+        // When
+        subject.process(exportedMetric);
+    }
+}

--- a/src/test/java/com/statful/client/framework/springboot/processor/processors/system/HeapProcessorTest.java
+++ b/src/test/java/com/statful/client/framework/springboot/processor/processors/system/HeapProcessorTest.java
@@ -1,0 +1,79 @@
+package com.statful.client.framework.springboot.processor.processors.system;
+
+import com.statful.client.framework.springboot.common.ExportedMetric;
+import com.statful.client.framework.springboot.common.MetricType;
+import com.statful.client.framework.springboot.common.ProcessedMetric;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.time.Instant;
+import java.util.Date;
+
+import static com.statful.client.framework.springboot.processor.MetricProcessor.SYSTEM_METRICS_PREFIX;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+public class HeapProcessorTest {
+
+    private HeapProcessor subject;
+
+    @Before
+    public void before() {
+        subject = new HeapProcessor();
+    }
+
+    @Test
+    public void shouldProcessMetricWithoutType() {
+        // Given
+        ExportedMetric exportedMetric = new ExportedMetric.Builder()
+                .withName("heap")
+                .withTimestamp(Date.from(Instant.EPOCH))
+                .withValue(1D)
+                .build();
+
+        // When
+        ProcessedMetric processedMetric = subject.process(exportedMetric);
+
+        // Then
+        assertEquals(SYSTEM_METRICS_PREFIX + "heap", processedMetric.getName());
+        assertEquals(MetricType.GAUGE, processedMetric.getMetricType());
+        assertEquals(Double.valueOf(1D), processedMetric.getValue());
+        assertEquals(Instant.EPOCH.toEpochMilli(), processedMetric.getTimestamp());
+        assertEquals("max", processedMetric.getTags().get().getTagValue("type"));
+        assertFalse(processedMetric.getAggregations().isPresent());
+        assertFalse(processedMetric.getAggregationDetails().isPresent());
+    }
+
+    @Test
+    public void shouldProcessMetricWithType() {
+        // Given
+        ExportedMetric exportedMetric = new ExportedMetric.Builder()
+                .withName("heap.init")
+                .withTimestamp(Date.from(Instant.EPOCH))
+                .withValue(1D)
+                .build();
+
+        // When
+        ProcessedMetric processedMetric = subject.process(exportedMetric);
+
+        // Then
+        assertEquals(SYSTEM_METRICS_PREFIX + "heap", processedMetric.getName());
+        assertEquals(MetricType.GAUGE, processedMetric.getMetricType());
+        assertEquals(Double.valueOf(1D), processedMetric.getValue());
+        assertEquals(Instant.EPOCH.toEpochMilli(), processedMetric.getTimestamp());
+        assertEquals("init", processedMetric.getTags().get().getTagValue("type"));
+        assertFalse(processedMetric.getAggregations().isPresent());
+        assertFalse(processedMetric.getAggregationDetails().isPresent());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldThrowIllegalArgumentExceptionIfInvalidMetric() {
+        // Given
+        ExportedMetric exportedMetric = new ExportedMetric.Builder()
+                .withName("this.is.an.invalid.metric.for.sure")
+                .build();
+
+        // When
+        subject.process(exportedMetric);
+    }
+}

--- a/src/test/java/com/statful/client/framework/springboot/processor/processors/system/MemProcessorTest.java
+++ b/src/test/java/com/statful/client/framework/springboot/processor/processors/system/MemProcessorTest.java
@@ -1,0 +1,79 @@
+package com.statful.client.framework.springboot.processor.processors.system;
+
+import com.statful.client.framework.springboot.common.ExportedMetric;
+import com.statful.client.framework.springboot.common.MetricType;
+import com.statful.client.framework.springboot.common.ProcessedMetric;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.time.Instant;
+import java.util.Date;
+
+import static com.statful.client.framework.springboot.processor.MetricProcessor.SYSTEM_METRICS_PREFIX;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+public class MemProcessorTest {
+
+    private MemProcessor subject;
+
+    @Before
+    public void before() {
+        subject = new MemProcessor();
+    }
+
+    @Test
+    public void shouldProcessMetricWithoutType() {
+        // Given
+        ExportedMetric exportedMetric = new ExportedMetric.Builder()
+                .withName("mem")
+                .withTimestamp(Date.from(Instant.EPOCH))
+                .withValue(1D)
+                .build();
+
+        // When
+        ProcessedMetric processedMetric = subject.process(exportedMetric);
+
+        // Then
+        assertEquals(SYSTEM_METRICS_PREFIX + "mem", processedMetric.getName());
+        assertEquals(MetricType.GAUGE, processedMetric.getMetricType());
+        assertEquals(Double.valueOf(1D), processedMetric.getValue());
+        assertEquals(Instant.EPOCH.toEpochMilli(), processedMetric.getTimestamp());
+        assertEquals("total", processedMetric.getTags().get().getTagValue("type"));
+        assertFalse(processedMetric.getAggregations().isPresent());
+        assertFalse(processedMetric.getAggregationDetails().isPresent());
+    }
+
+    @Test
+    public void shouldProcessMetricWithType() {
+        // Given
+        ExportedMetric exportedMetric = new ExportedMetric.Builder()
+                .withName("mem.free")
+                .withTimestamp(Date.from(Instant.EPOCH))
+                .withValue(1D)
+                .build();
+
+        // When
+        ProcessedMetric processedMetric = subject.process(exportedMetric);
+
+        // Then
+        assertEquals(SYSTEM_METRICS_PREFIX + "mem", processedMetric.getName());
+        assertEquals(MetricType.GAUGE, processedMetric.getMetricType());
+        assertEquals(Double.valueOf(1D), processedMetric.getValue());
+        assertEquals(Instant.EPOCH.toEpochMilli(), processedMetric.getTimestamp());
+        assertEquals("free", processedMetric.getTags().get().getTagValue("type"));
+        assertFalse(processedMetric.getAggregations().isPresent());
+        assertFalse(processedMetric.getAggregationDetails().isPresent());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldThrowIllegalArgumentExceptionIfInvalidMetric() {
+        // Given
+        ExportedMetric exportedMetric = new ExportedMetric.Builder()
+                .withName("this.is.an.invalid.metric.for.sure")
+                .build();
+
+        // When
+        subject.process(exportedMetric);
+    }
+}

--- a/src/test/java/com/statful/client/framework/springboot/processor/processors/system/ProcessorsProcessorTest.java
+++ b/src/test/java/com/statful/client/framework/springboot/processor/processors/system/ProcessorsProcessorTest.java
@@ -1,0 +1,46 @@
+package com.statful.client.framework.springboot.processor.processors.system;
+
+import com.statful.client.framework.springboot.common.ExportedMetric;
+import com.statful.client.framework.springboot.common.MetricType;
+import com.statful.client.framework.springboot.common.ProcessedMetric;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.time.Instant;
+import java.util.Date;
+
+import static com.statful.client.framework.springboot.processor.MetricProcessor.SYSTEM_METRICS_PREFIX;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+public class ProcessorsProcessorTest {
+
+    private ProcessorsProcessor subject;
+
+    @Before
+    public void before() {
+        subject = new ProcessorsProcessor();
+    }
+
+    @Test
+    public void shouldProcessMetric() {
+        // Given
+        ExportedMetric exportedMetric = new ExportedMetric.Builder()
+                .withName("processors")
+                .withTimestamp(Date.from(Instant.EPOCH))
+                .withValue(1D)
+                .build();
+
+        // When
+        ProcessedMetric processedMetric = subject.process(exportedMetric);
+
+        // Then
+        assertEquals(SYSTEM_METRICS_PREFIX + "processors", processedMetric.getName());
+        assertEquals(MetricType.GAUGE, processedMetric.getMetricType());
+        assertEquals(Double.valueOf(1D), processedMetric.getValue());
+        assertEquals(Instant.EPOCH.toEpochMilli(), processedMetric.getTimestamp());
+        assertFalse(processedMetric.getAggregations().isPresent());
+        assertFalse(processedMetric.getTags().isPresent());
+        assertFalse(processedMetric.getAggregationDetails().isPresent());
+    }
+}

--- a/src/test/java/com/statful/client/framework/springboot/processor/processors/system/SystemLoadProcessorTest.java
+++ b/src/test/java/com/statful/client/framework/springboot/processor/processors/system/SystemLoadProcessorTest.java
@@ -1,0 +1,71 @@
+package com.statful.client.framework.springboot.processor.processors.system;
+
+import com.statful.client.domain.api.Aggregation;
+import com.statful.client.domain.api.AggregationFrequency;
+import com.statful.client.framework.springboot.common.ExportedMetric;
+import com.statful.client.framework.springboot.common.MetricType;
+import com.statful.client.framework.springboot.common.ProcessedMetric;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.time.Instant;
+import java.util.Date;
+
+import static com.statful.client.framework.springboot.processor.MetricProcessor.SYSTEM_METRICS_PREFIX;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+public class SystemLoadProcessorTest {
+
+    private SystemLoadProcessor subject;
+
+    @Before
+    public void before() {
+        subject = new SystemLoadProcessor();
+    }
+
+    @Test
+    public void shouldProcessMetric() {
+        // Given
+        ExportedMetric exportedMetric = new ExportedMetric.Builder()
+                .withName("systemload.average")
+                .withTimestamp(Date.from(Instant.EPOCH))
+                .withValue(1D)
+                .build();
+
+        // When
+        ProcessedMetric processedMetric = subject.process(exportedMetric);
+
+        // Then
+        assertEquals(SYSTEM_METRICS_PREFIX + "systemload", processedMetric.getName());
+        assertEquals(MetricType.GAUGE, processedMetric.getMetricType());
+        assertEquals(Double.valueOf(1D), processedMetric.getValue());
+        assertEquals(Instant.EPOCH.toEpochMilli(), processedMetric.getTimestamp());
+        assertFalse(processedMetric.getTags().isPresent());
+        assertFalse(processedMetric.getAggregations().isPresent());
+        assertEquals(Aggregation.AVG, processedMetric.getAggregationDetails().get().getAggregation());
+        assertEquals(AggregationFrequency.FREQ_60, processedMetric.getAggregationDetails().get().getAggregationFrequency());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldThrowIllegalArgumentExceptionIfInvalidMetricDueToTooManyParts() {
+        // Given
+        ExportedMetric exportedMetric = new ExportedMetric.Builder()
+                .withName("this.is.an.invalid.metric.for.sure")
+                .build();
+
+        // When
+        subject.process(exportedMetric);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldThrowIllegalArgumentExceptionIfInvalidMetricDueToNotEnoughParts() {
+        // Given
+        ExportedMetric exportedMetric = new ExportedMetric.Builder()
+                .withName("invalid")
+                .build();
+
+        // When
+        subject.process(exportedMetric);
+    }
+}

--- a/src/test/java/com/statful/client/framework/springboot/processor/processors/system/ThreadsProcessorTest.java
+++ b/src/test/java/com/statful/client/framework/springboot/processor/processors/system/ThreadsProcessorTest.java
@@ -1,0 +1,79 @@
+package com.statful.client.framework.springboot.processor.processors.system;
+
+import com.statful.client.framework.springboot.common.ExportedMetric;
+import com.statful.client.framework.springboot.common.MetricType;
+import com.statful.client.framework.springboot.common.ProcessedMetric;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.time.Instant;
+import java.util.Date;
+
+import static com.statful.client.framework.springboot.processor.MetricProcessor.SYSTEM_METRICS_PREFIX;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+public class ThreadsProcessorTest {
+
+    private ThreadsProcessor subject;
+
+    @Before
+    public void before() {
+        subject = new ThreadsProcessor();
+    }
+
+    @Test
+    public void shouldProcessMetricWithoutType() {
+        // Given
+        ExportedMetric exportedMetric = new ExportedMetric.Builder()
+                .withName("threads")
+                .withTimestamp(Date.from(Instant.EPOCH))
+                .withValue(1D)
+                .build();
+
+        // When
+        ProcessedMetric processedMetric = subject.process(exportedMetric);
+
+        // Then
+        assertEquals(SYSTEM_METRICS_PREFIX + "threads", processedMetric.getName());
+        assertEquals(MetricType.GAUGE, processedMetric.getMetricType());
+        assertEquals(Double.valueOf(1D), processedMetric.getValue());
+        assertEquals(Instant.EPOCH.toEpochMilli(), processedMetric.getTimestamp());
+        assertEquals("total", processedMetric.getTags().get().getTagValue("type"));
+        assertFalse(processedMetric.getAggregations().isPresent());
+        assertFalse(processedMetric.getAggregationDetails().isPresent());
+    }
+
+    @Test
+    public void shouldProcessMetricWithType() {
+        // Given
+        ExportedMetric exportedMetric = new ExportedMetric.Builder()
+                .withName("threads.peak")
+                .withTimestamp(Date.from(Instant.EPOCH))
+                .withValue(1D)
+                .build();
+
+        // When
+        ProcessedMetric processedMetric = subject.process(exportedMetric);
+
+        // Then
+        assertEquals(SYSTEM_METRICS_PREFIX + "threads", processedMetric.getName());
+        assertEquals(MetricType.GAUGE, processedMetric.getMetricType());
+        assertEquals(Double.valueOf(1D), processedMetric.getValue());
+        assertEquals(Instant.EPOCH.toEpochMilli(), processedMetric.getTimestamp());
+        assertEquals("peak", processedMetric.getTags().get().getTagValue("type"));
+        assertFalse(processedMetric.getAggregations().isPresent());
+        assertFalse(processedMetric.getAggregationDetails().isPresent());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldThrowIllegalArgumentExceptionIfInvalidMetric() {
+        // Given
+        ExportedMetric exportedMetric = new ExportedMetric.Builder()
+                .withName("this.is.an.invalid.metric.for.sure")
+                .build();
+
+        // When
+        subject.process(exportedMetric);
+    }
+}

--- a/src/test/java/com/statful/client/framework/springboot/processor/processors/system/UptimeProcessorTest.java
+++ b/src/test/java/com/statful/client/framework/springboot/processor/processors/system/UptimeProcessorTest.java
@@ -1,0 +1,79 @@
+package com.statful.client.framework.springboot.processor.processors.system;
+
+import com.statful.client.framework.springboot.common.ExportedMetric;
+import com.statful.client.framework.springboot.common.MetricType;
+import com.statful.client.framework.springboot.common.ProcessedMetric;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.time.Instant;
+import java.util.Date;
+
+import static com.statful.client.framework.springboot.processor.MetricProcessor.SYSTEM_METRICS_PREFIX;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+public class UptimeProcessorTest {
+
+    private UptimeProcessor subject;
+
+    @Before
+    public void before() {
+        subject = new UptimeProcessor();
+    }
+
+    @Test
+    public void shouldProcessMetricWithoutType() {
+        // Given
+        ExportedMetric exportedMetric = new ExportedMetric.Builder()
+                .withName("uptime")
+                .withTimestamp(Date.from(Instant.EPOCH))
+                .withValue(1D)
+                .build();
+
+        // When
+        ProcessedMetric processedMetric = subject.process(exportedMetric);
+
+        // Then
+        assertEquals(SYSTEM_METRICS_PREFIX + "uptime", processedMetric.getName());
+        assertEquals(MetricType.GAUGE, processedMetric.getMetricType());
+        assertEquals(Double.valueOf(1D), processedMetric.getValue());
+        assertEquals(Instant.EPOCH.toEpochMilli(), processedMetric.getTimestamp());
+        assertEquals("vm", processedMetric.getTags().get().getTagValue("type"));
+        assertFalse(processedMetric.getAggregations().isPresent());
+        assertFalse(processedMetric.getAggregationDetails().isPresent());
+    }
+
+    @Test
+    public void shouldProcessMetricWithType() {
+        // Given
+        ExportedMetric exportedMetric = new ExportedMetric.Builder()
+                .withName("instance.uptime")
+                .withTimestamp(Date.from(Instant.EPOCH))
+                .withValue(1D)
+                .build();
+
+        // When
+        ProcessedMetric processedMetric = subject.process(exportedMetric);
+
+        // Then
+        assertEquals(SYSTEM_METRICS_PREFIX + "uptime", processedMetric.getName());
+        assertEquals(MetricType.GAUGE, processedMetric.getMetricType());
+        assertEquals(Double.valueOf(1D), processedMetric.getValue());
+        assertEquals(Instant.EPOCH.toEpochMilli(), processedMetric.getTimestamp());
+        assertEquals("instance", processedMetric.getTags().get().getTagValue("type"));
+        assertFalse(processedMetric.getAggregations().isPresent());
+        assertFalse(processedMetric.getAggregationDetails().isPresent());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldThrowIllegalArgumentExceptionIfInvalidMetric() {
+        // Given
+        ExportedMetric exportedMetric = new ExportedMetric.Builder()
+                .withName("this.is.an.invalid.metric.for.sure")
+                .build();
+
+        // When
+        subject.process(exportedMetric);
+    }
+}

--- a/src/test/java/com/statful/client/framework/springboot/processor/processors/tomcat/HttpSessionsProcessorTest.java
+++ b/src/test/java/com/statful/client/framework/springboot/processor/processors/tomcat/HttpSessionsProcessorTest.java
@@ -1,0 +1,57 @@
+package com.statful.client.framework.springboot.processor.processors.tomcat;
+
+import com.statful.client.framework.springboot.common.ExportedMetric;
+import com.statful.client.framework.springboot.common.MetricType;
+import com.statful.client.framework.springboot.common.ProcessedMetric;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.time.Instant;
+import java.util.Date;
+
+import static com.statful.client.framework.springboot.processor.MetricProcessor.TOMCAT_METRICS_PREFIX;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+public class HttpSessionsProcessorTest {
+
+    private HttpSessionsProcessor subject;
+
+    @Before
+    public void before() {
+        subject = new HttpSessionsProcessor();
+    }
+
+    @Test
+    public void shouldProcessMetric() {
+        // Given
+        ExportedMetric exportedMetric = new ExportedMetric.Builder()
+                .withName("httpsessions.max")
+                .withTimestamp(Date.from(Instant.EPOCH))
+                .withValue(1D)
+                .build();
+
+        // When
+        ProcessedMetric processedMetric = subject.process(exportedMetric);
+
+        // Then
+        assertEquals(TOMCAT_METRICS_PREFIX + "httpsessions", processedMetric.getName());
+        assertEquals(MetricType.GAUGE, processedMetric.getMetricType());
+        assertEquals(Double.valueOf(1D), processedMetric.getValue());
+        assertEquals(Instant.EPOCH.toEpochMilli(), processedMetric.getTimestamp());
+        assertEquals("max", processedMetric.getTags().get().getTagValue("type"));
+        assertFalse(processedMetric.getAggregations().isPresent());
+        assertFalse(processedMetric.getAggregationDetails().isPresent());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldThrowIllegalArgumentExceptionIfInvalidMetric() {
+        // Given
+        ExportedMetric exportedMetric = new ExportedMetric.Builder()
+                .withName("this.is.an.invalid.metric.for.sure")
+                .build();
+
+        // When
+        subject.process(exportedMetric);
+    }
+}

--- a/src/test/java/com/statful/client/framework/springboot/proxy/StatfulClientProxyTest.java
+++ b/src/test/java/com/statful/client/framework/springboot/proxy/StatfulClientProxyTest.java
@@ -1,0 +1,221 @@
+package com.statful.client.framework.springboot.proxy;
+
+import com.statful.client.core.StatfulFactory;
+import com.statful.client.domain.api.*;
+import com.statful.client.framework.springboot.common.AggregationDetails;
+import com.statful.client.framework.springboot.common.MetricType;
+import com.statful.client.framework.springboot.common.ProcessedMetric;
+import com.statful.client.framework.springboot.config.SpringbootClientConfiguration;
+import com.statful.client.framework.springboot.processor.StatfulMetricProcessor;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.springframework.boot.actuate.metrics.Metric;
+import org.springframework.boot.actuate.metrics.writer.Delta;
+
+import java.util.Collections;
+
+import static com.statful.client.framework.springboot.config.SpringbootClientConfiguration.Metrics;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.*;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+public class StatfulClientProxyTest {
+
+    private static String PREFIX = "prefix";
+    private static String NAMESPACE = "namespace";
+    private static String METRIC_NAME = "gc.test.foo";
+    private static String INGESTED_METRIC_NAME = PREFIX + ".counter.gc.test.foo";
+    private static Metrics.Tags GLOBAL_TAGS = new Metrics.Tags();
+    private static String CUSTOM_TAG_KEY = "customKey";
+    private static String CUSTOM_TAG_VALUE = "customValue";
+    private static Tags CUSTOM_TAGS = Tags.from(CUSTOM_TAG_KEY, CUSTOM_TAG_VALUE);
+
+    @Mock
+    private SpringbootClientConfiguration springbootClientConfiguration;
+
+    @Mock
+    private StatfulMetricProcessor statfulMetricProcessor;
+
+    @Mock
+    private StatfulClient statfulClient = StatfulFactory.buildHTTPClient().with().isDryRun(true).build();
+
+    private StatfulClientProxy subject;
+
+    @Before
+    public void before() {
+        initMocks(this);
+
+        when(springbootClientConfiguration.getMetrics()).thenReturn(buildDefaultMetrics());
+
+        subject = new StatfulClientProxy();
+        subject.setSpringbootClientConfiguration(springbootClientConfiguration);
+        subject.setStatfulMetricProcessor(statfulMetricProcessor);
+        subject.setStatfulClient(statfulClient);
+        subject.setMetricsPrefix(PREFIX);
+        subject.setMetricsNamespace(NAMESPACE);
+    }
+
+    private Metrics buildDefaultMetrics() {
+        GLOBAL_TAGS.setName("globalKey");
+        GLOBAL_TAGS.setValue("globalValue");
+
+        Metrics metrics = new Metrics();
+        metrics.setTags(Collections.singletonList(GLOBAL_TAGS));
+
+        return metrics;
+    }
+
+    @Test
+    public void shouldIngestFromDelta() {
+        // Given
+        when(statfulMetricProcessor.validate(any())).thenReturn(true);
+        ProcessedMetric processedMetric = getProcessedMetric();
+        when(statfulMetricProcessor.process(any())).thenReturn(processedMetric);
+        Delta delta = new Delta<>(METRIC_NAME, 1L);
+
+        // When
+        subject.ingestMetric(delta);
+
+        // Then
+        verify(statfulClient).put(eq(INGESTED_METRIC_NAME), eq(Double.toString(1L)), any(Tags.class), eq(null),
+                eq(null), anyInt(), eq(NAMESPACE), anyInt());
+    }
+
+    @Test
+    public void shouldIngestFromMetric() {
+        // Given
+        when(statfulMetricProcessor.validate(any())).thenReturn(true);
+        ProcessedMetric processedMetric = getProcessedMetric();
+        when(statfulMetricProcessor.process(any())).thenReturn(processedMetric);
+        Metric metric = new Metric<>(METRIC_NAME, 1L);
+
+        // When
+        subject.ingestMetric(metric);
+
+        // Then
+        verify(statfulClient).put(eq(INGESTED_METRIC_NAME), eq(Double.toString(1L)), any(Tags.class), eq(null),
+                eq(null), anyInt(), eq(NAMESPACE), anyInt());
+    }
+
+    @Test
+    public void shouldIngestFromAggregatedMetric() {
+        // Given
+        when(statfulMetricProcessor.validate(any())).thenReturn(true);
+        ProcessedMetric processedMetric = getProcessedAggregatedMetric();
+        when(statfulMetricProcessor.process(any())).thenReturn(processedMetric);
+        Metric metric = new Metric<>(METRIC_NAME, 1L);
+
+        // When
+        subject.ingestMetric(metric);
+
+        // Then
+        verify(statfulClient).aggregatedPut(eq(INGESTED_METRIC_NAME), eq(Double.toString(1L)), any(Tags.class),
+                any(Aggregation.class), any(AggregationFrequency.class), anyInt(), eq(NAMESPACE), anyInt());
+    }
+
+    @Test
+    public void shouldIngestMetricWithDefaultGlobalTags() {
+        // Given
+        when(statfulMetricProcessor.validate(any())).thenReturn(true);
+        ProcessedMetric processedMetric = getProcessedMetric();
+        when(statfulMetricProcessor.process(any())).thenReturn(processedMetric);
+        Metric metric = new Metric<>(METRIC_NAME, 1L);
+
+        // When
+        subject.ingestMetric(metric);
+
+        // Then
+        ArgumentCaptor<Tags> tags = ArgumentCaptor.forClass(Tags.class);
+        verify(statfulClient).put(eq(INGESTED_METRIC_NAME), eq(Double.toString(1L)), tags.capture(), eq(null), eq(null),
+                anyInt(), eq(NAMESPACE), anyInt());
+        assertEquals(GLOBAL_TAGS.getValue(), tags.getValue().getTagValue(GLOBAL_TAGS.getName()));
+    }
+
+    @Test
+    public void shouldIngestMetricWithMergedTags() {
+        // Given
+        when(statfulMetricProcessor.validate(any())).thenReturn(true);
+        ProcessedMetric processedMetric = getProcessedMetricWithTags();
+        when(statfulMetricProcessor.process(any())).thenReturn(processedMetric);
+        Metric metric = new Metric<>(METRIC_NAME, 1L);
+
+        // When
+        subject.ingestMetric(metric);
+
+        // Then
+        ArgumentCaptor<Tags> tags = ArgumentCaptor.forClass(Tags.class);
+        verify(statfulClient).put(eq(INGESTED_METRIC_NAME), eq(Double.toString(1L)), tags.capture(), eq(null), eq(null),
+                anyInt(), eq(NAMESPACE), anyInt());
+        assertEquals(GLOBAL_TAGS.getValue(), tags.getValue().getTagValue(GLOBAL_TAGS.getName()));
+        assertEquals(CUSTOM_TAG_VALUE, tags.getValue().getTagValue(CUSTOM_TAG_KEY));
+    }
+
+    @Test
+    public void shouldIngestMetricWithAggregations() {
+        // Given
+        when(statfulMetricProcessor.validate(any())).thenReturn(true);
+        ProcessedMetric processedMetric = getProcessedMetricWithAggregations();
+        when(statfulMetricProcessor.process(any())).thenReturn(processedMetric);
+        Metric metric = new Metric<>(METRIC_NAME, 1L);
+
+        // When
+        subject.ingestMetric(metric);
+
+        // Then
+        ArgumentCaptor<Aggregations> aggregations = ArgumentCaptor.forClass(Aggregations.class);
+        verify(statfulClient).put(eq(INGESTED_METRIC_NAME), eq(Double.toString(1L)), any(Tags.class),
+                aggregations.capture(), eq(null), anyInt(), eq(NAMESPACE), anyInt());
+        assertEquals(Aggregation.AVG, aggregations.getValue().getAggregations().stream().findFirst().get());
+    }
+
+    @Test
+    public void shouldNotIngestUnknownMetricProcessor() {
+        // Given
+        when(statfulMetricProcessor.validate(any())).thenReturn(false);
+
+        // When
+        subject.ingestMetric(new Metric<Number>("unknown", 1L));
+
+        // Then
+        verifyNoMoreInteractions(statfulClient);
+    }
+
+    private ProcessedMetric getProcessedMetric() {
+        return new ProcessedMetric.Builder()
+                    .withName(METRIC_NAME)
+                    .withMetricType(MetricType.COUNTER)
+                    .withValue((double) 1L)
+                    .build();
+    }
+
+    private ProcessedMetric getProcessedMetricWithTags() {
+        return new ProcessedMetric.Builder()
+                .withName(METRIC_NAME)
+                .withMetricType(MetricType.COUNTER)
+                .withTags(CUSTOM_TAGS)
+                .withValue((double) 1L)
+                .build();
+    }
+
+    private ProcessedMetric getProcessedMetricWithAggregations() {
+        return new ProcessedMetric.Builder()
+                .withName(METRIC_NAME)
+                .withMetricType(MetricType.COUNTER)
+                .withAggregations(Aggregations.from(Aggregation.AVG))
+                .withValue((double) 1L)
+                .build();
+    }
+
+    private ProcessedMetric getProcessedAggregatedMetric() {
+        return new ProcessedMetric.Builder()
+                .withName(METRIC_NAME)
+                .withMetricType(MetricType.COUNTER)
+                .withValue((double) 1L)
+                .aggregatedBy(new AggregationDetails(Aggregation.AVG, AggregationFrequency.FREQ_10))
+                .build();
+    }
+
+}

--- a/src/test/java/com/statful/client/framework/springboot/writer/StatfulMetricWriterTest.java
+++ b/src/test/java/com/statful/client/framework/springboot/writer/StatfulMetricWriterTest.java
@@ -1,0 +1,57 @@
+package com.statful.client.framework.springboot.writer;
+
+import com.statful.client.framework.springboot.proxy.StatfulClientProxy;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.springframework.boot.actuate.metrics.Metric;
+import org.springframework.boot.actuate.metrics.writer.Delta;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+public class StatfulMetricWriterTest {
+
+    private StatfulMetricWriter subject;
+
+    @Mock
+    private StatfulClientProxy statfulClientProxy;
+
+    @Before
+    public void before() {
+        initMocks(this);
+
+        subject = new StatfulMetricWriter();
+        subject.setStatfulClientProxy(statfulClientProxy);
+    }
+
+    @Test
+    public void shouldIngestMetricOnIncrement() {
+        // When
+        Delta delta = new Delta<>("foo", 1L);
+        subject.increment(delta);
+
+        // Then
+        verify(statfulClientProxy).ingestMetric(delta);
+    }
+
+    @Test
+    public void shouldIngestMetricOnSet() {
+        // When
+        Metric metric = new Metric<>("bar", 2L);
+        subject.set(metric);
+
+        // Then
+        verify(statfulClientProxy).ingestMetric(metric);
+    }
+
+    @Test
+    public void shouldStubOnReset() {
+        // When
+        subject.reset("zed");
+
+        // Then
+        verifyNoMoreInteractions(statfulClientProxy);
+    }
+}


### PR DESCRIPTION
I still need to update the client-java dep and add javadoc across the estate. I also want to run some more tests against a starter project I'm building. Anyway I think it's good for review.

Metrics are currently validated against a whitelist based on the metric name. I believe that, although restrictive this is the easiest way to make sure we only process metrics we understand. I'm open to suggestions for future iterations.

Next iterations will most likely include support for Datasource and Cache metrics as described in [here](http://docs.spring.io/spring-boot/docs/current/reference/html/production-ready-metrics.html) since it seems simple straightforward.

We might want to include support for Custom metrics and Dropwizard but I don't see that as being as simple to do.
