### PR TITLE
fix(NA) - Fix metric timestamp generation.

### DIFF
--- a/src/main/java/com/statful/client/framework/springboot/common/ExportedMetric.java
+++ b/src/main/java/com/statful/client/framework/springboot/common/ExportedMetric.java
@@ -1,6 +1,5 @@
 package com.statful.client.framework.springboot.common;
 
-import java.util.Date;
 import java.util.Objects;
 
 /**
@@ -8,8 +7,8 @@ import java.util.Objects;
  */
 public class ExportedMetric {
     private String name;
-    private Number value;
-    private Date timestamp;
+    private double value;
+    private long timestamp;
 
     /**
      * Builder constructor.
@@ -25,31 +24,31 @@ public class ExportedMetric {
         return name;
     }
 
-    public Number getValue() {
+    public double getValue() {
         return value;
     }
 
-    public Date getTimestamp() {
+    public long getTimestamp() {
         return timestamp;
     }
 
     public static final class Builder {
 
         private String name;
-        private Number value;
-        private Date timestamp;
+        private double value;
+        private long timestamp;
 
         public Builder withName(String name) {
             this.name = Objects.requireNonNull(name, "Metric name cannot be null");
             return this;
         }
 
-        public Builder withValue(Number value) {
+        public Builder withValue(double value) {
             this.value = Objects.requireNonNull(value, "Value cannot be null");
             return this;
         }
 
-        public Builder withTimestamp(Date timestamp) {
+        public Builder withTimestamp(long timestamp) {
             this.timestamp = Objects.requireNonNull(timestamp, "Timestamp cannot be null");
             return this;
         }

--- a/src/main/java/com/statful/client/framework/springboot/processor/GenericProcessor.java
+++ b/src/main/java/com/statful/client/framework/springboot/processor/GenericProcessor.java
@@ -21,7 +21,7 @@ public final class GenericProcessor {
      * @param timestamp {@link long} Metric timestamp
      * @return {@link ProcessedMetric} Processed metric
      */
-    public static ProcessedMetric process(String name, MetricType metricType, Double value, long timestamp) {
+    public static ProcessedMetric process(String name, MetricType metricType, double value, long timestamp) {
         return new ProcessedMetric.Builder().withName(name)
                 .withMetricType(metricType)
                 .withValue(value)

--- a/src/main/java/com/statful/client/framework/springboot/processor/processors/http/HttpRequestsProcessor.java
+++ b/src/main/java/com/statful/client/framework/springboot/processor/processors/http/HttpRequestsProcessor.java
@@ -66,8 +66,8 @@ public class HttpRequestsProcessor implements MetricProcessor {
         return new ProcessedMetric.Builder().withName(REQUESTS_NAME)
                 .withTags(tags)
                 .withMetricType(MetricType.COUNTER)
-                .withValue(exportedMetric.getValue().doubleValue())
-                .withTimestamp(exportedMetric.getTimestamp().getTime())
+                .withValue(exportedMetric.getValue())
+                .withTimestamp(exportedMetric.getTimestamp())
                 .build();
     }
 
@@ -78,8 +78,8 @@ public class HttpRequestsProcessor implements MetricProcessor {
         return new ProcessedMetric.Builder().withName(RESPONSES_NAME)
                 .withTags(tags)
                 .withMetricType(MetricType.TIMER)
-                .withValue(exportedMetric.getValue().doubleValue())
-                .withTimestamp(exportedMetric.getTimestamp().getTime())
+                .withValue(exportedMetric.getValue())
+                .withTimestamp(exportedMetric.getTimestamp())
                 .build();
     }
 }

--- a/src/main/java/com/statful/client/framework/springboot/processor/processors/system/ClassesProcessor.java
+++ b/src/main/java/com/statful/client/framework/springboot/processor/processors/system/ClassesProcessor.java
@@ -46,8 +46,8 @@ public class ClassesProcessor implements MetricProcessor {
         return new ProcessedMetric.Builder().withName(SYSTEM_METRICS_PREFIX + metricSplit[0])
                 .withTags(tags)
                 .withMetricType(MetricType.GAUGE)
-                .withValue(exportedMetric.getValue().doubleValue())
-                .withTimestamp(exportedMetric.getTimestamp().getTime())
+                .withValue(exportedMetric.getValue())
+                .withTimestamp(exportedMetric.getTimestamp())
                 .build();
     }
 

--- a/src/main/java/com/statful/client/framework/springboot/processor/processors/system/GcProcessor.java
+++ b/src/main/java/com/statful/client/framework/springboot/processor/processors/system/GcProcessor.java
@@ -49,8 +49,8 @@ public class GcProcessor implements MetricProcessor {
         return new ProcessedMetric.Builder().withName(SYSTEM_METRICS_PREFIX + ACCUMULATED_METRICS_PREFIX + metricSplit[0])
                 .withTags(tags)
                 .withMetricType(metricType)
-                .withValue(exportedMetric.getValue().doubleValue())
-                .withTimestamp(exportedMetric.getTimestamp().getTime())
+                .withValue(exportedMetric.getValue())
+                .withTimestamp(exportedMetric.getTimestamp())
                 .build();
     }
 

--- a/src/main/java/com/statful/client/framework/springboot/processor/processors/system/HeapProcessor.java
+++ b/src/main/java/com/statful/client/framework/springboot/processor/processors/system/HeapProcessor.java
@@ -47,8 +47,8 @@ public class HeapProcessor implements MetricProcessor {
         return new ProcessedMetric.Builder().withName(SYSTEM_METRICS_PREFIX + metricSplit[0])
                 .withTags(tags)
                 .withMetricType(MetricType.GAUGE)
-                .withValue(exportedMetric.getValue().doubleValue())
-                .withTimestamp(exportedMetric.getTimestamp().getTime())
+                .withValue(exportedMetric.getValue())
+                .withTimestamp(exportedMetric.getTimestamp())
                 .build();
     }
 

--- a/src/main/java/com/statful/client/framework/springboot/processor/processors/system/MemProcessor.java
+++ b/src/main/java/com/statful/client/framework/springboot/processor/processors/system/MemProcessor.java
@@ -44,8 +44,8 @@ public class MemProcessor implements MetricProcessor {
         return new ProcessedMetric.Builder().withName(SYSTEM_METRICS_PREFIX + metricSplit[0])
                 .withTags(tags)
                 .withMetricType(MetricType.GAUGE)
-                .withValue(exportedMetric.getValue().doubleValue())
-                .withTimestamp(exportedMetric.getTimestamp().getTime())
+                .withValue(exportedMetric.getValue())
+                .withTimestamp(exportedMetric.getTimestamp())
                 .build();
     }
 

--- a/src/main/java/com/statful/client/framework/springboot/processor/processors/system/ProcessorsProcessor.java
+++ b/src/main/java/com/statful/client/framework/springboot/processor/processors/system/ProcessorsProcessor.java
@@ -25,7 +25,7 @@ public class ProcessorsProcessor implements MetricProcessor {
     @Override
     public ProcessedMetric process(ExportedMetric exportedMetric) {
         return GenericProcessor.process(SYSTEM_METRICS_PREFIX + exportedMetric.getName(),
-                MetricType.GAUGE, exportedMetric.getValue().doubleValue(), exportedMetric.getTimestamp().getTime());
+                MetricType.GAUGE, exportedMetric.getValue(), exportedMetric.getTimestamp());
     }
 
     @Override

--- a/src/main/java/com/statful/client/framework/springboot/processor/processors/system/SystemLoadProcessor.java
+++ b/src/main/java/com/statful/client/framework/springboot/processor/processors/system/SystemLoadProcessor.java
@@ -34,8 +34,8 @@ public class SystemLoadProcessor implements MetricProcessor {
 
         return new ProcessedMetric.Builder().withName(SYSTEM_METRICS_PREFIX + metricSplit[0])
                 .withMetricType(MetricType.GAUGE)
-                .withValue(exportedMetric.getValue().doubleValue())
-                .withTimestamp(exportedMetric.getTimestamp().getTime())
+                .withValue(exportedMetric.getValue())
+                .withTimestamp(exportedMetric.getTimestamp())
                 .aggregatedBy(new AggregationDetails(Aggregation.AVG, AggregationFrequency.FREQ_60))
                 .build();
     }

--- a/src/main/java/com/statful/client/framework/springboot/processor/processors/system/ThreadsProcessor.java
+++ b/src/main/java/com/statful/client/framework/springboot/processor/processors/system/ThreadsProcessor.java
@@ -47,8 +47,8 @@ public class ThreadsProcessor implements MetricProcessor {
         return new ProcessedMetric.Builder().withName(SYSTEM_METRICS_PREFIX + metricSplit[0])
                 .withTags(tags)
                 .withMetricType(MetricType.GAUGE)
-                .withValue(exportedMetric.getValue().doubleValue())
-                .withTimestamp(exportedMetric.getTimestamp().getTime())
+                .withValue(exportedMetric.getValue())
+                .withTimestamp(exportedMetric.getTimestamp())
                 .build();
     }
 

--- a/src/main/java/com/statful/client/framework/springboot/processor/processors/system/UptimeProcessor.java
+++ b/src/main/java/com/statful/client/framework/springboot/processor/processors/system/UptimeProcessor.java
@@ -45,8 +45,8 @@ public class UptimeProcessor implements MetricProcessor {
         return new ProcessedMetric.Builder().withName(UPTIME_NAME)
                 .withTags(tags)
                 .withMetricType(MetricType.GAUGE)
-                .withValue(exportedMetric.getValue().doubleValue())
-                .withTimestamp(exportedMetric.getTimestamp().getTime())
+                .withValue(exportedMetric.getValue())
+                .withTimestamp(exportedMetric.getTimestamp())
                 .build();
     }
 

--- a/src/main/java/com/statful/client/framework/springboot/processor/processors/tomcat/HttpSessionsProcessor.java
+++ b/src/main/java/com/statful/client/framework/springboot/processor/processors/tomcat/HttpSessionsProcessor.java
@@ -36,8 +36,8 @@ public class HttpSessionsProcessor implements MetricProcessor {
         return new ProcessedMetric.Builder().withName(TOMCAT_METRICS_PREFIX + metricSplit[0])
                 .withTags(tags)
                 .withMetricType(MetricType.GAUGE)
-                .withValue(exportedMetric.getValue().doubleValue())
-                .withTimestamp(exportedMetric.getTimestamp().getTime())
+                .withValue(exportedMetric.getValue())
+                .withTimestamp(exportedMetric.getTimestamp())
                 .build();
     }
 

--- a/src/main/java/com/statful/client/framework/springboot/proxy/StatfulClientProxy.java
+++ b/src/main/java/com/statful/client/framework/springboot/proxy/StatfulClientProxy.java
@@ -47,8 +47,8 @@ public class StatfulClientProxy {
     public void ingestMetric(Metric<?> metric) {
         ExportedMetric exportedMetric = new ExportedMetric.Builder()
                 .withName(metric.getName())
-                .withValue(metric.getValue())
-                .withTimestamp(metric.getTimestamp())
+                .withValue(metric.getValue().doubleValue())
+                .withTimestamp(metric.getTimestamp().getTime() / 1000L)
                 .build();
 
         ingest(exportedMetric);
@@ -62,8 +62,8 @@ public class StatfulClientProxy {
     public void ingestMetric(Delta<?> delta) {
         ExportedMetric exportedMetric = new ExportedMetric.Builder()
                 .withName(delta.getName())
-                .withValue(delta.getValue())
-                .withTimestamp(delta.getTimestamp())
+                .withValue(delta.getValue().doubleValue())
+                .withTimestamp(delta.getTimestamp().getTime() / 1000L)
                 .build();
 
         ingest(exportedMetric);

--- a/src/test/java/com/statful/client/framework/springboot/processor/AbstractProcessorTest.java
+++ b/src/test/java/com/statful/client/framework/springboot/processor/AbstractProcessorTest.java
@@ -1,0 +1,8 @@
+package com.statful.client.framework.springboot.processor;
+
+import java.time.Instant;
+
+public abstract class AbstractProcessorTest {
+    protected final static long EPOCH_SECONDS_PLUS_10_SECS = Instant.EPOCH.plusSeconds(10).getEpochSecond();
+    protected final static double METRIC_VALUE = 1D;
+}

--- a/src/test/java/com/statful/client/framework/springboot/processor/GenericProcessorTest.java
+++ b/src/test/java/com/statful/client/framework/springboot/processor/GenericProcessorTest.java
@@ -14,7 +14,7 @@ public class GenericProcessorTest {
         // Given
         String name = "foo";
         MetricType type = MetricType.COUNTER;
-        Double value = 1D;
+        double value = 1D;
         long timestamp = 123456789L;
 
         // When
@@ -23,7 +23,7 @@ public class GenericProcessorTest {
         // Then
         assertEquals(name, processedMetric.getName());
         assertEquals(type, processedMetric.getMetricType());
-        assertEquals(value, processedMetric.getValue());
+        assertEquals(Double.valueOf(value), processedMetric.getValue());
         assertEquals(timestamp, processedMetric.getTimestamp());
         assertFalse(processedMetric.getAggregations().isPresent());
         assertFalse(processedMetric.getTags().isPresent());

--- a/src/test/java/com/statful/client/framework/springboot/processor/StatfulMetricProcessorTest.java
+++ b/src/test/java/com/statful/client/framework/springboot/processor/StatfulMetricProcessorTest.java
@@ -42,7 +42,7 @@ public class StatfulMetricProcessorTest {
         EXPORTED_METRIC = new ExportedMetric.Builder()
                 .withName(GC_PS_SCAVENGE_COUNT)
                 .withValue(1D)
-                .withTimestamp(Date.from(Instant.EPOCH))
+                .withTimestamp(Date.from(Instant.EPOCH.plusSeconds(10)).getTime() / 1000L)
                 .build();
     }
 
@@ -78,7 +78,7 @@ public class StatfulMetricProcessorTest {
         assertEquals(SYSTEM_METRICS_PREFIX + ACCUMULATED_METRICS_PREFIX + "gc", processedMetric.getName());
         assertEquals(MetricType.COUNTER, processedMetric.getMetricType());
         assertEquals(Double.valueOf(1D), processedMetric.getValue());
-        assertEquals(Instant.EPOCH.toEpochMilli(), processedMetric.getTimestamp());
+        assertEquals(Instant.EPOCH.plusSeconds(10).getEpochSecond(), processedMetric.getTimestamp());
         assertEquals("ps_scavenge", processedMetric.getTags().get().getTagValue("name"));
         assertFalse(processedMetric.getAggregations().isPresent());
         assertFalse(processedMetric.getAggregationDetails().isPresent());

--- a/src/test/java/com/statful/client/framework/springboot/processor/StatfulMetricProcessorTest.java
+++ b/src/test/java/com/statful/client/framework/springboot/processor/StatfulMetricProcessorTest.java
@@ -8,16 +8,13 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
 
-import java.time.Instant;
-import java.util.Date;
-
 import static com.statful.client.framework.springboot.processor.MetricProcessor.ACCUMULATED_METRICS_PREFIX;
 import static com.statful.client.framework.springboot.processor.MetricProcessor.SYSTEM_METRICS_PREFIX;
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
 
-public class StatfulMetricProcessorTest {
+public class StatfulMetricProcessorTest extends AbstractProcessorTest {
 
     private static final String GC_PS_SCAVENGE_COUNT = "gc.ps_scavenge.count";
     private static final String INVALID = "invalid";
@@ -41,8 +38,8 @@ public class StatfulMetricProcessorTest {
 
         EXPORTED_METRIC = new ExportedMetric.Builder()
                 .withName(GC_PS_SCAVENGE_COUNT)
-                .withValue(1D)
-                .withTimestamp(Date.from(Instant.EPOCH.plusSeconds(10)).getTime() / 1000L)
+                .withValue(METRIC_VALUE)
+                .withTimestamp(EPOCH_SECONDS_PLUS_10_SECS)
                 .build();
     }
 
@@ -77,8 +74,8 @@ public class StatfulMetricProcessorTest {
         // Then
         assertEquals(SYSTEM_METRICS_PREFIX + ACCUMULATED_METRICS_PREFIX + "gc", processedMetric.getName());
         assertEquals(MetricType.COUNTER, processedMetric.getMetricType());
-        assertEquals(Double.valueOf(1D), processedMetric.getValue());
-        assertEquals(Instant.EPOCH.plusSeconds(10).getEpochSecond(), processedMetric.getTimestamp());
+        assertEquals(Double.valueOf(METRIC_VALUE), processedMetric.getValue());
+        assertEquals(EPOCH_SECONDS_PLUS_10_SECS, processedMetric.getTimestamp());
         assertEquals("ps_scavenge", processedMetric.getTags().get().getTagValue("name"));
         assertFalse(processedMetric.getAggregations().isPresent());
         assertFalse(processedMetric.getAggregationDetails().isPresent());

--- a/src/test/java/com/statful/client/framework/springboot/processor/processors/http/HttpRequestProcessorTest.java
+++ b/src/test/java/com/statful/client/framework/springboot/processor/processors/http/HttpRequestProcessorTest.java
@@ -7,7 +7,6 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.time.Instant;
-import java.util.Date;
 
 import static com.statful.client.framework.springboot.processor.MetricProcessor.ACCUMULATED_METRICS_PREFIX;
 import static com.statful.client.framework.springboot.processor.MetricProcessor.LATEST_METRICS_PREFIX;
@@ -28,7 +27,7 @@ public class HttpRequestProcessorTest {
         // Given
         ExportedMetric exportedMetric = new ExportedMetric.Builder()
                 .withName("counter.status.200.star-star.favicon.ico")
-                .withTimestamp(Date.from(Instant.EPOCH))
+                .withTimestamp(Instant.EPOCH.plusSeconds(10).getEpochSecond())
                 .withValue(1D)
                 .build();
 
@@ -39,7 +38,7 @@ public class HttpRequestProcessorTest {
         assertEquals(ACCUMULATED_METRICS_PREFIX + "requests", processedMetric.getName());
         assertEquals(MetricType.COUNTER, processedMetric.getMetricType());
         assertEquals(Double.valueOf(1D), processedMetric.getValue());
-        assertEquals(Instant.EPOCH.toEpochMilli(), processedMetric.getTimestamp());
+        assertEquals(Instant.EPOCH.plusSeconds(10).getEpochSecond(), processedMetric.getTimestamp());
         assertEquals("200", processedMetric.getTags().get().getTagValue("status"));
         assertEquals("star-star.favicon.ico", processedMetric.getTags().get().getTagValue("url"));
         assertFalse(processedMetric.getAggregations().isPresent());
@@ -51,7 +50,7 @@ public class HttpRequestProcessorTest {
         // Given
         ExportedMetric exportedMetric = new ExportedMetric.Builder()
                 .withName("gauge.response.star-star.favicon.ico")
-                .withTimestamp(Date.from(Instant.EPOCH))
+                .withTimestamp(Instant.EPOCH.plusSeconds(10).getEpochSecond())
                 .withValue(1D)
                 .build();
 
@@ -62,7 +61,7 @@ public class HttpRequestProcessorTest {
         assertEquals(LATEST_METRICS_PREFIX + "responses", processedMetric.getName());
         assertEquals(MetricType.TIMER, processedMetric.getMetricType());
         assertEquals(Double.valueOf(1D), processedMetric.getValue());
-        assertEquals(Instant.EPOCH.toEpochMilli(), processedMetric.getTimestamp());
+        assertEquals(Instant.EPOCH.plusSeconds(10).getEpochSecond(), processedMetric.getTimestamp());
         assertEquals("star-star.favicon.ico", processedMetric.getTags().get().getTagValue("url"));
         assertFalse(processedMetric.getAggregations().isPresent());
         assertFalse(processedMetric.getAggregationDetails().isPresent());

--- a/src/test/java/com/statful/client/framework/springboot/processor/processors/http/HttpRequestProcessorTest.java
+++ b/src/test/java/com/statful/client/framework/springboot/processor/processors/http/HttpRequestProcessorTest.java
@@ -3,17 +3,16 @@ package com.statful.client.framework.springboot.processor.processors.http;
 import com.statful.client.framework.springboot.common.ExportedMetric;
 import com.statful.client.framework.springboot.common.MetricType;
 import com.statful.client.framework.springboot.common.ProcessedMetric;
+import com.statful.client.framework.springboot.processor.AbstractProcessorTest;
 import org.junit.Before;
 import org.junit.Test;
-
-import java.time.Instant;
 
 import static com.statful.client.framework.springboot.processor.MetricProcessor.ACCUMULATED_METRICS_PREFIX;
 import static com.statful.client.framework.springboot.processor.MetricProcessor.LATEST_METRICS_PREFIX;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 
-public class HttpRequestProcessorTest {
+public class HttpRequestProcessorTest extends AbstractProcessorTest {
 
     private HttpRequestsProcessor subject;
 
@@ -27,8 +26,8 @@ public class HttpRequestProcessorTest {
         // Given
         ExportedMetric exportedMetric = new ExportedMetric.Builder()
                 .withName("counter.status.200.star-star.favicon.ico")
-                .withTimestamp(Instant.EPOCH.plusSeconds(10).getEpochSecond())
-                .withValue(1D)
+                .withTimestamp(EPOCH_SECONDS_PLUS_10_SECS)
+                .withValue(METRIC_VALUE)
                 .build();
 
         // When
@@ -37,8 +36,8 @@ public class HttpRequestProcessorTest {
         // Then
         assertEquals(ACCUMULATED_METRICS_PREFIX + "requests", processedMetric.getName());
         assertEquals(MetricType.COUNTER, processedMetric.getMetricType());
-        assertEquals(Double.valueOf(1D), processedMetric.getValue());
-        assertEquals(Instant.EPOCH.plusSeconds(10).getEpochSecond(), processedMetric.getTimestamp());
+        assertEquals(Double.valueOf(METRIC_VALUE), processedMetric.getValue());
+        assertEquals(EPOCH_SECONDS_PLUS_10_SECS, processedMetric.getTimestamp());
         assertEquals("200", processedMetric.getTags().get().getTagValue("status"));
         assertEquals("star-star.favicon.ico", processedMetric.getTags().get().getTagValue("url"));
         assertFalse(processedMetric.getAggregations().isPresent());
@@ -50,8 +49,8 @@ public class HttpRequestProcessorTest {
         // Given
         ExportedMetric exportedMetric = new ExportedMetric.Builder()
                 .withName("gauge.response.star-star.favicon.ico")
-                .withTimestamp(Instant.EPOCH.plusSeconds(10).getEpochSecond())
-                .withValue(1D)
+                .withTimestamp(EPOCH_SECONDS_PLUS_10_SECS)
+                .withValue(METRIC_VALUE)
                 .build();
 
         // When
@@ -60,8 +59,8 @@ public class HttpRequestProcessorTest {
         // Then
         assertEquals(LATEST_METRICS_PREFIX + "responses", processedMetric.getName());
         assertEquals(MetricType.TIMER, processedMetric.getMetricType());
-        assertEquals(Double.valueOf(1D), processedMetric.getValue());
-        assertEquals(Instant.EPOCH.plusSeconds(10).getEpochSecond(), processedMetric.getTimestamp());
+        assertEquals(Double.valueOf(METRIC_VALUE), processedMetric.getValue());
+        assertEquals(EPOCH_SECONDS_PLUS_10_SECS, processedMetric.getTimestamp());
         assertEquals("star-star.favicon.ico", processedMetric.getTags().get().getTagValue("url"));
         assertFalse(processedMetric.getAggregations().isPresent());
         assertFalse(processedMetric.getAggregationDetails().isPresent());

--- a/src/test/java/com/statful/client/framework/springboot/processor/processors/system/ClassesProcessorTest.java
+++ b/src/test/java/com/statful/client/framework/springboot/processor/processors/system/ClassesProcessorTest.java
@@ -7,7 +7,6 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.time.Instant;
-import java.util.Date;
 
 import static com.statful.client.framework.springboot.processor.MetricProcessor.SYSTEM_METRICS_PREFIX;
 import static org.junit.Assert.assertEquals;
@@ -27,7 +26,7 @@ public class ClassesProcessorTest {
         // Given
         ExportedMetric exportedMetric = new ExportedMetric.Builder()
                 .withName("classes")
-                .withTimestamp(Date.from(Instant.EPOCH))
+                .withTimestamp(Instant.EPOCH.plusSeconds(10).getEpochSecond())
                 .withValue(1D)
                 .build();
 
@@ -38,7 +37,7 @@ public class ClassesProcessorTest {
         assertEquals(SYSTEM_METRICS_PREFIX + "classes", processedMetric.getName());
         assertEquals(MetricType.GAUGE, processedMetric.getMetricType());
         assertEquals(Double.valueOf(1D), processedMetric.getValue());
-        assertEquals(Instant.EPOCH.toEpochMilli(), processedMetric.getTimestamp());
+        assertEquals(Instant.EPOCH.plusSeconds(10).getEpochSecond(), processedMetric.getTimestamp());
         assertEquals("total", processedMetric.getTags().get().getTagValue("type"));
         assertFalse(processedMetric.getAggregations().isPresent());
         assertFalse(processedMetric.getAggregationDetails().isPresent());
@@ -49,7 +48,7 @@ public class ClassesProcessorTest {
         // Given
         ExportedMetric exportedMetric = new ExportedMetric.Builder()
                 .withName("classes.loaded")
-                .withTimestamp(Date.from(Instant.EPOCH))
+                .withTimestamp(Instant.EPOCH.plusSeconds(10).getEpochSecond())
                 .withValue(1D)
                 .build();
 
@@ -60,7 +59,7 @@ public class ClassesProcessorTest {
         assertEquals(SYSTEM_METRICS_PREFIX + "classes", processedMetric.getName());
         assertEquals(MetricType.GAUGE, processedMetric.getMetricType());
         assertEquals(Double.valueOf(1D), processedMetric.getValue());
-        assertEquals(Instant.EPOCH.toEpochMilli(), processedMetric.getTimestamp());
+        assertEquals(Instant.EPOCH.plusSeconds(10).getEpochSecond(), processedMetric.getTimestamp());
         assertEquals("loaded", processedMetric.getTags().get().getTagValue("type"));
         assertFalse(processedMetric.getAggregations().isPresent());
         assertFalse(processedMetric.getAggregationDetails().isPresent());

--- a/src/test/java/com/statful/client/framework/springboot/processor/processors/system/ClassesProcessorTest.java
+++ b/src/test/java/com/statful/client/framework/springboot/processor/processors/system/ClassesProcessorTest.java
@@ -3,16 +3,15 @@ package com.statful.client.framework.springboot.processor.processors.system;
 import com.statful.client.framework.springboot.common.ExportedMetric;
 import com.statful.client.framework.springboot.common.MetricType;
 import com.statful.client.framework.springboot.common.ProcessedMetric;
+import com.statful.client.framework.springboot.processor.AbstractProcessorTest;
 import org.junit.Before;
 import org.junit.Test;
-
-import java.time.Instant;
 
 import static com.statful.client.framework.springboot.processor.MetricProcessor.SYSTEM_METRICS_PREFIX;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 
-public class ClassesProcessorTest {
+public class ClassesProcessorTest extends AbstractProcessorTest {
 
     private ClassesProcessor subject;
 
@@ -26,8 +25,8 @@ public class ClassesProcessorTest {
         // Given
         ExportedMetric exportedMetric = new ExportedMetric.Builder()
                 .withName("classes")
-                .withTimestamp(Instant.EPOCH.plusSeconds(10).getEpochSecond())
-                .withValue(1D)
+                .withTimestamp(EPOCH_SECONDS_PLUS_10_SECS)
+                .withValue(METRIC_VALUE)
                 .build();
 
         // When
@@ -36,8 +35,8 @@ public class ClassesProcessorTest {
         // Then
         assertEquals(SYSTEM_METRICS_PREFIX + "classes", processedMetric.getName());
         assertEquals(MetricType.GAUGE, processedMetric.getMetricType());
-        assertEquals(Double.valueOf(1D), processedMetric.getValue());
-        assertEquals(Instant.EPOCH.plusSeconds(10).getEpochSecond(), processedMetric.getTimestamp());
+        assertEquals(Double.valueOf(METRIC_VALUE), processedMetric.getValue());
+        assertEquals(EPOCH_SECONDS_PLUS_10_SECS, processedMetric.getTimestamp());
         assertEquals("total", processedMetric.getTags().get().getTagValue("type"));
         assertFalse(processedMetric.getAggregations().isPresent());
         assertFalse(processedMetric.getAggregationDetails().isPresent());
@@ -48,8 +47,8 @@ public class ClassesProcessorTest {
         // Given
         ExportedMetric exportedMetric = new ExportedMetric.Builder()
                 .withName("classes.loaded")
-                .withTimestamp(Instant.EPOCH.plusSeconds(10).getEpochSecond())
-                .withValue(1D)
+                .withTimestamp(EPOCH_SECONDS_PLUS_10_SECS)
+                .withValue(METRIC_VALUE)
                 .build();
 
         // When
@@ -58,8 +57,8 @@ public class ClassesProcessorTest {
         // Then
         assertEquals(SYSTEM_METRICS_PREFIX + "classes", processedMetric.getName());
         assertEquals(MetricType.GAUGE, processedMetric.getMetricType());
-        assertEquals(Double.valueOf(1D), processedMetric.getValue());
-        assertEquals(Instant.EPOCH.plusSeconds(10).getEpochSecond(), processedMetric.getTimestamp());
+        assertEquals(Double.valueOf(METRIC_VALUE), processedMetric.getValue());
+        assertEquals(EPOCH_SECONDS_PLUS_10_SECS, processedMetric.getTimestamp());
         assertEquals("loaded", processedMetric.getTags().get().getTagValue("type"));
         assertFalse(processedMetric.getAggregations().isPresent());
         assertFalse(processedMetric.getAggregationDetails().isPresent());

--- a/src/test/java/com/statful/client/framework/springboot/processor/processors/system/GcProcessorTest.java
+++ b/src/test/java/com/statful/client/framework/springboot/processor/processors/system/GcProcessorTest.java
@@ -3,17 +3,16 @@ package com.statful.client.framework.springboot.processor.processors.system;
 import com.statful.client.framework.springboot.common.ExportedMetric;
 import com.statful.client.framework.springboot.common.MetricType;
 import com.statful.client.framework.springboot.common.ProcessedMetric;
+import com.statful.client.framework.springboot.processor.AbstractProcessorTest;
 import org.junit.Before;
 import org.junit.Test;
-
-import java.time.Instant;
 
 import static com.statful.client.framework.springboot.processor.MetricProcessor.ACCUMULATED_METRICS_PREFIX;
 import static com.statful.client.framework.springboot.processor.MetricProcessor.SYSTEM_METRICS_PREFIX;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 
-public class GcProcessorTest {
+public class GcProcessorTest extends AbstractProcessorTest {
 
     private GcProcessor subject;
 
@@ -27,8 +26,8 @@ public class GcProcessorTest {
         // Given
         ExportedMetric exportedMetric = new ExportedMetric.Builder()
                 .withName("gc.ps_scavenge.count")
-                .withTimestamp(Instant.EPOCH.plusSeconds(10).getEpochSecond())
-                .withValue(1D)
+                .withTimestamp(EPOCH_SECONDS_PLUS_10_SECS)
+                .withValue(METRIC_VALUE)
                 .build();
 
         // When
@@ -37,8 +36,8 @@ public class GcProcessorTest {
         // Then
         assertEquals(SYSTEM_METRICS_PREFIX + ACCUMULATED_METRICS_PREFIX + "gc", processedMetric.getName());
         assertEquals(MetricType.COUNTER, processedMetric.getMetricType());
-        assertEquals(Double.valueOf(1D), processedMetric.getValue());
-        assertEquals(Instant.EPOCH.plusSeconds(10).getEpochSecond(), processedMetric.getTimestamp());
+        assertEquals(Double.valueOf(METRIC_VALUE), processedMetric.getValue());
+        assertEquals(EPOCH_SECONDS_PLUS_10_SECS, processedMetric.getTimestamp());
         assertEquals("ps_scavenge", processedMetric.getTags().get().getTagValue("name"));
         assertFalse(processedMetric.getAggregations().isPresent());
         assertFalse(processedMetric.getAggregationDetails().isPresent());
@@ -49,8 +48,8 @@ public class GcProcessorTest {
         // Given
         ExportedMetric exportedMetric = new ExportedMetric.Builder()
                 .withName("gc.ps_scavenge.time")
-                .withTimestamp(Instant.EPOCH.plusSeconds(10).getEpochSecond())
-                .withValue(1D)
+                .withTimestamp(EPOCH_SECONDS_PLUS_10_SECS)
+                .withValue(METRIC_VALUE)
                 .build();
 
         // When
@@ -59,8 +58,8 @@ public class GcProcessorTest {
         // Then
         assertEquals(SYSTEM_METRICS_PREFIX + ACCUMULATED_METRICS_PREFIX + "gc", processedMetric.getName());
         assertEquals(MetricType.TIMER, processedMetric.getMetricType());
-        assertEquals(Double.valueOf(1D), processedMetric.getValue());
-        assertEquals(Instant.EPOCH.plusSeconds(10).getEpochSecond(), processedMetric.getTimestamp());
+        assertEquals(Double.valueOf(METRIC_VALUE), processedMetric.getValue());
+        assertEquals(EPOCH_SECONDS_PLUS_10_SECS, processedMetric.getTimestamp());
         assertEquals("ps_scavenge", processedMetric.getTags().get().getTagValue("name"));
         assertFalse(processedMetric.getAggregations().isPresent());
         assertFalse(processedMetric.getAggregationDetails().isPresent());

--- a/src/test/java/com/statful/client/framework/springboot/processor/processors/system/GcProcessorTest.java
+++ b/src/test/java/com/statful/client/framework/springboot/processor/processors/system/GcProcessorTest.java
@@ -7,7 +7,6 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.time.Instant;
-import java.util.Date;
 
 import static com.statful.client.framework.springboot.processor.MetricProcessor.ACCUMULATED_METRICS_PREFIX;
 import static com.statful.client.framework.springboot.processor.MetricProcessor.SYSTEM_METRICS_PREFIX;
@@ -28,7 +27,7 @@ public class GcProcessorTest {
         // Given
         ExportedMetric exportedMetric = new ExportedMetric.Builder()
                 .withName("gc.ps_scavenge.count")
-                .withTimestamp(Date.from(Instant.EPOCH))
+                .withTimestamp(Instant.EPOCH.plusSeconds(10).getEpochSecond())
                 .withValue(1D)
                 .build();
 
@@ -39,7 +38,7 @@ public class GcProcessorTest {
         assertEquals(SYSTEM_METRICS_PREFIX + ACCUMULATED_METRICS_PREFIX + "gc", processedMetric.getName());
         assertEquals(MetricType.COUNTER, processedMetric.getMetricType());
         assertEquals(Double.valueOf(1D), processedMetric.getValue());
-        assertEquals(Instant.EPOCH.toEpochMilli(), processedMetric.getTimestamp());
+        assertEquals(Instant.EPOCH.plusSeconds(10).getEpochSecond(), processedMetric.getTimestamp());
         assertEquals("ps_scavenge", processedMetric.getTags().get().getTagValue("name"));
         assertFalse(processedMetric.getAggregations().isPresent());
         assertFalse(processedMetric.getAggregationDetails().isPresent());
@@ -50,7 +49,7 @@ public class GcProcessorTest {
         // Given
         ExportedMetric exportedMetric = new ExportedMetric.Builder()
                 .withName("gc.ps_scavenge.time")
-                .withTimestamp(Date.from(Instant.EPOCH))
+                .withTimestamp(Instant.EPOCH.plusSeconds(10).getEpochSecond())
                 .withValue(1D)
                 .build();
 
@@ -61,7 +60,7 @@ public class GcProcessorTest {
         assertEquals(SYSTEM_METRICS_PREFIX + ACCUMULATED_METRICS_PREFIX + "gc", processedMetric.getName());
         assertEquals(MetricType.TIMER, processedMetric.getMetricType());
         assertEquals(Double.valueOf(1D), processedMetric.getValue());
-        assertEquals(Instant.EPOCH.toEpochMilli(), processedMetric.getTimestamp());
+        assertEquals(Instant.EPOCH.plusSeconds(10).getEpochSecond(), processedMetric.getTimestamp());
         assertEquals("ps_scavenge", processedMetric.getTags().get().getTagValue("name"));
         assertFalse(processedMetric.getAggregations().isPresent());
         assertFalse(processedMetric.getAggregationDetails().isPresent());

--- a/src/test/java/com/statful/client/framework/springboot/processor/processors/system/HeapProcessorTest.java
+++ b/src/test/java/com/statful/client/framework/springboot/processor/processors/system/HeapProcessorTest.java
@@ -7,7 +7,6 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.time.Instant;
-import java.util.Date;
 
 import static com.statful.client.framework.springboot.processor.MetricProcessor.SYSTEM_METRICS_PREFIX;
 import static org.junit.Assert.assertEquals;
@@ -27,7 +26,7 @@ public class HeapProcessorTest {
         // Given
         ExportedMetric exportedMetric = new ExportedMetric.Builder()
                 .withName("heap")
-                .withTimestamp(Date.from(Instant.EPOCH))
+                .withTimestamp(Instant.EPOCH.plusSeconds(10).getEpochSecond())
                 .withValue(1D)
                 .build();
 
@@ -38,7 +37,7 @@ public class HeapProcessorTest {
         assertEquals(SYSTEM_METRICS_PREFIX + "heap", processedMetric.getName());
         assertEquals(MetricType.GAUGE, processedMetric.getMetricType());
         assertEquals(Double.valueOf(1D), processedMetric.getValue());
-        assertEquals(Instant.EPOCH.toEpochMilli(), processedMetric.getTimestamp());
+        assertEquals(Instant.EPOCH.plusSeconds(10).getEpochSecond(), processedMetric.getTimestamp());
         assertEquals("max", processedMetric.getTags().get().getTagValue("type"));
         assertFalse(processedMetric.getAggregations().isPresent());
         assertFalse(processedMetric.getAggregationDetails().isPresent());
@@ -49,7 +48,7 @@ public class HeapProcessorTest {
         // Given
         ExportedMetric exportedMetric = new ExportedMetric.Builder()
                 .withName("heap.init")
-                .withTimestamp(Date.from(Instant.EPOCH))
+                .withTimestamp(Instant.EPOCH.plusSeconds(10).getEpochSecond())
                 .withValue(1D)
                 .build();
 
@@ -60,7 +59,7 @@ public class HeapProcessorTest {
         assertEquals(SYSTEM_METRICS_PREFIX + "heap", processedMetric.getName());
         assertEquals(MetricType.GAUGE, processedMetric.getMetricType());
         assertEquals(Double.valueOf(1D), processedMetric.getValue());
-        assertEquals(Instant.EPOCH.toEpochMilli(), processedMetric.getTimestamp());
+        assertEquals(Instant.EPOCH.plusSeconds(10).getEpochSecond(), processedMetric.getTimestamp());
         assertEquals("init", processedMetric.getTags().get().getTagValue("type"));
         assertFalse(processedMetric.getAggregations().isPresent());
         assertFalse(processedMetric.getAggregationDetails().isPresent());

--- a/src/test/java/com/statful/client/framework/springboot/processor/processors/system/HeapProcessorTest.java
+++ b/src/test/java/com/statful/client/framework/springboot/processor/processors/system/HeapProcessorTest.java
@@ -3,16 +3,15 @@ package com.statful.client.framework.springboot.processor.processors.system;
 import com.statful.client.framework.springboot.common.ExportedMetric;
 import com.statful.client.framework.springboot.common.MetricType;
 import com.statful.client.framework.springboot.common.ProcessedMetric;
+import com.statful.client.framework.springboot.processor.AbstractProcessorTest;
 import org.junit.Before;
 import org.junit.Test;
-
-import java.time.Instant;
 
 import static com.statful.client.framework.springboot.processor.MetricProcessor.SYSTEM_METRICS_PREFIX;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 
-public class HeapProcessorTest {
+public class HeapProcessorTest extends AbstractProcessorTest {
 
     private HeapProcessor subject;
 
@@ -26,8 +25,8 @@ public class HeapProcessorTest {
         // Given
         ExportedMetric exportedMetric = new ExportedMetric.Builder()
                 .withName("heap")
-                .withTimestamp(Instant.EPOCH.plusSeconds(10).getEpochSecond())
-                .withValue(1D)
+                .withTimestamp(EPOCH_SECONDS_PLUS_10_SECS)
+                .withValue(METRIC_VALUE)
                 .build();
 
         // When
@@ -36,8 +35,8 @@ public class HeapProcessorTest {
         // Then
         assertEquals(SYSTEM_METRICS_PREFIX + "heap", processedMetric.getName());
         assertEquals(MetricType.GAUGE, processedMetric.getMetricType());
-        assertEquals(Double.valueOf(1D), processedMetric.getValue());
-        assertEquals(Instant.EPOCH.plusSeconds(10).getEpochSecond(), processedMetric.getTimestamp());
+        assertEquals(Double.valueOf(METRIC_VALUE), processedMetric.getValue());
+        assertEquals(EPOCH_SECONDS_PLUS_10_SECS, processedMetric.getTimestamp());
         assertEquals("max", processedMetric.getTags().get().getTagValue("type"));
         assertFalse(processedMetric.getAggregations().isPresent());
         assertFalse(processedMetric.getAggregationDetails().isPresent());
@@ -48,8 +47,8 @@ public class HeapProcessorTest {
         // Given
         ExportedMetric exportedMetric = new ExportedMetric.Builder()
                 .withName("heap.init")
-                .withTimestamp(Instant.EPOCH.plusSeconds(10).getEpochSecond())
-                .withValue(1D)
+                .withTimestamp(EPOCH_SECONDS_PLUS_10_SECS)
+                .withValue(METRIC_VALUE)
                 .build();
 
         // When
@@ -58,8 +57,8 @@ public class HeapProcessorTest {
         // Then
         assertEquals(SYSTEM_METRICS_PREFIX + "heap", processedMetric.getName());
         assertEquals(MetricType.GAUGE, processedMetric.getMetricType());
-        assertEquals(Double.valueOf(1D), processedMetric.getValue());
-        assertEquals(Instant.EPOCH.plusSeconds(10).getEpochSecond(), processedMetric.getTimestamp());
+        assertEquals(Double.valueOf(METRIC_VALUE), processedMetric.getValue());
+        assertEquals(EPOCH_SECONDS_PLUS_10_SECS, processedMetric.getTimestamp());
         assertEquals("init", processedMetric.getTags().get().getTagValue("type"));
         assertFalse(processedMetric.getAggregations().isPresent());
         assertFalse(processedMetric.getAggregationDetails().isPresent());

--- a/src/test/java/com/statful/client/framework/springboot/processor/processors/system/MemProcessorTest.java
+++ b/src/test/java/com/statful/client/framework/springboot/processor/processors/system/MemProcessorTest.java
@@ -7,7 +7,6 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.time.Instant;
-import java.util.Date;
 
 import static com.statful.client.framework.springboot.processor.MetricProcessor.SYSTEM_METRICS_PREFIX;
 import static org.junit.Assert.assertEquals;
@@ -27,7 +26,7 @@ public class MemProcessorTest {
         // Given
         ExportedMetric exportedMetric = new ExportedMetric.Builder()
                 .withName("mem")
-                .withTimestamp(Date.from(Instant.EPOCH))
+                .withTimestamp(Instant.EPOCH.plusSeconds(10).getEpochSecond())
                 .withValue(1D)
                 .build();
 
@@ -38,7 +37,7 @@ public class MemProcessorTest {
         assertEquals(SYSTEM_METRICS_PREFIX + "mem", processedMetric.getName());
         assertEquals(MetricType.GAUGE, processedMetric.getMetricType());
         assertEquals(Double.valueOf(1D), processedMetric.getValue());
-        assertEquals(Instant.EPOCH.toEpochMilli(), processedMetric.getTimestamp());
+        assertEquals(Instant.EPOCH.plusSeconds(10).getEpochSecond(), processedMetric.getTimestamp());
         assertEquals("total", processedMetric.getTags().get().getTagValue("type"));
         assertFalse(processedMetric.getAggregations().isPresent());
         assertFalse(processedMetric.getAggregationDetails().isPresent());
@@ -49,7 +48,7 @@ public class MemProcessorTest {
         // Given
         ExportedMetric exportedMetric = new ExportedMetric.Builder()
                 .withName("mem.free")
-                .withTimestamp(Date.from(Instant.EPOCH))
+                .withTimestamp(Instant.EPOCH.plusSeconds(10).getEpochSecond())
                 .withValue(1D)
                 .build();
 
@@ -60,7 +59,7 @@ public class MemProcessorTest {
         assertEquals(SYSTEM_METRICS_PREFIX + "mem", processedMetric.getName());
         assertEquals(MetricType.GAUGE, processedMetric.getMetricType());
         assertEquals(Double.valueOf(1D), processedMetric.getValue());
-        assertEquals(Instant.EPOCH.toEpochMilli(), processedMetric.getTimestamp());
+        assertEquals(Instant.EPOCH.plusSeconds(10).getEpochSecond(), processedMetric.getTimestamp());
         assertEquals("free", processedMetric.getTags().get().getTagValue("type"));
         assertFalse(processedMetric.getAggregations().isPresent());
         assertFalse(processedMetric.getAggregationDetails().isPresent());

--- a/src/test/java/com/statful/client/framework/springboot/processor/processors/system/MemProcessorTest.java
+++ b/src/test/java/com/statful/client/framework/springboot/processor/processors/system/MemProcessorTest.java
@@ -3,16 +3,15 @@ package com.statful.client.framework.springboot.processor.processors.system;
 import com.statful.client.framework.springboot.common.ExportedMetric;
 import com.statful.client.framework.springboot.common.MetricType;
 import com.statful.client.framework.springboot.common.ProcessedMetric;
+import com.statful.client.framework.springboot.processor.AbstractProcessorTest;
 import org.junit.Before;
 import org.junit.Test;
-
-import java.time.Instant;
 
 import static com.statful.client.framework.springboot.processor.MetricProcessor.SYSTEM_METRICS_PREFIX;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 
-public class MemProcessorTest {
+public class MemProcessorTest extends AbstractProcessorTest {
 
     private MemProcessor subject;
 
@@ -26,8 +25,8 @@ public class MemProcessorTest {
         // Given
         ExportedMetric exportedMetric = new ExportedMetric.Builder()
                 .withName("mem")
-                .withTimestamp(Instant.EPOCH.plusSeconds(10).getEpochSecond())
-                .withValue(1D)
+                .withTimestamp(EPOCH_SECONDS_PLUS_10_SECS)
+                .withValue(METRIC_VALUE)
                 .build();
 
         // When
@@ -36,8 +35,8 @@ public class MemProcessorTest {
         // Then
         assertEquals(SYSTEM_METRICS_PREFIX + "mem", processedMetric.getName());
         assertEquals(MetricType.GAUGE, processedMetric.getMetricType());
-        assertEquals(Double.valueOf(1D), processedMetric.getValue());
-        assertEquals(Instant.EPOCH.plusSeconds(10).getEpochSecond(), processedMetric.getTimestamp());
+        assertEquals(Double.valueOf(METRIC_VALUE), processedMetric.getValue());
+        assertEquals(EPOCH_SECONDS_PLUS_10_SECS, processedMetric.getTimestamp());
         assertEquals("total", processedMetric.getTags().get().getTagValue("type"));
         assertFalse(processedMetric.getAggregations().isPresent());
         assertFalse(processedMetric.getAggregationDetails().isPresent());
@@ -48,8 +47,8 @@ public class MemProcessorTest {
         // Given
         ExportedMetric exportedMetric = new ExportedMetric.Builder()
                 .withName("mem.free")
-                .withTimestamp(Instant.EPOCH.plusSeconds(10).getEpochSecond())
-                .withValue(1D)
+                .withTimestamp(EPOCH_SECONDS_PLUS_10_SECS)
+                .withValue(METRIC_VALUE)
                 .build();
 
         // When
@@ -58,8 +57,8 @@ public class MemProcessorTest {
         // Then
         assertEquals(SYSTEM_METRICS_PREFIX + "mem", processedMetric.getName());
         assertEquals(MetricType.GAUGE, processedMetric.getMetricType());
-        assertEquals(Double.valueOf(1D), processedMetric.getValue());
-        assertEquals(Instant.EPOCH.plusSeconds(10).getEpochSecond(), processedMetric.getTimestamp());
+        assertEquals(Double.valueOf(METRIC_VALUE), processedMetric.getValue());
+        assertEquals(EPOCH_SECONDS_PLUS_10_SECS, processedMetric.getTimestamp());
         assertEquals("free", processedMetric.getTags().get().getTagValue("type"));
         assertFalse(processedMetric.getAggregations().isPresent());
         assertFalse(processedMetric.getAggregationDetails().isPresent());

--- a/src/test/java/com/statful/client/framework/springboot/processor/processors/system/ProcessorsProcessorTest.java
+++ b/src/test/java/com/statful/client/framework/springboot/processor/processors/system/ProcessorsProcessorTest.java
@@ -7,7 +7,6 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.time.Instant;
-import java.util.Date;
 
 import static com.statful.client.framework.springboot.processor.MetricProcessor.SYSTEM_METRICS_PREFIX;
 import static org.junit.Assert.assertEquals;
@@ -27,7 +26,7 @@ public class ProcessorsProcessorTest {
         // Given
         ExportedMetric exportedMetric = new ExportedMetric.Builder()
                 .withName("processors")
-                .withTimestamp(Date.from(Instant.EPOCH))
+                .withTimestamp(Instant.EPOCH.plusSeconds(10).getEpochSecond())
                 .withValue(1D)
                 .build();
 
@@ -38,7 +37,7 @@ public class ProcessorsProcessorTest {
         assertEquals(SYSTEM_METRICS_PREFIX + "processors", processedMetric.getName());
         assertEquals(MetricType.GAUGE, processedMetric.getMetricType());
         assertEquals(Double.valueOf(1D), processedMetric.getValue());
-        assertEquals(Instant.EPOCH.toEpochMilli(), processedMetric.getTimestamp());
+        assertEquals(Instant.EPOCH.plusSeconds(10).getEpochSecond(), processedMetric.getTimestamp());
         assertFalse(processedMetric.getAggregations().isPresent());
         assertFalse(processedMetric.getTags().isPresent());
         assertFalse(processedMetric.getAggregationDetails().isPresent());

--- a/src/test/java/com/statful/client/framework/springboot/processor/processors/system/ProcessorsProcessorTest.java
+++ b/src/test/java/com/statful/client/framework/springboot/processor/processors/system/ProcessorsProcessorTest.java
@@ -3,16 +3,15 @@ package com.statful.client.framework.springboot.processor.processors.system;
 import com.statful.client.framework.springboot.common.ExportedMetric;
 import com.statful.client.framework.springboot.common.MetricType;
 import com.statful.client.framework.springboot.common.ProcessedMetric;
+import com.statful.client.framework.springboot.processor.AbstractProcessorTest;
 import org.junit.Before;
 import org.junit.Test;
-
-import java.time.Instant;
 
 import static com.statful.client.framework.springboot.processor.MetricProcessor.SYSTEM_METRICS_PREFIX;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 
-public class ProcessorsProcessorTest {
+public class ProcessorsProcessorTest extends AbstractProcessorTest {
 
     private ProcessorsProcessor subject;
 
@@ -26,8 +25,8 @@ public class ProcessorsProcessorTest {
         // Given
         ExportedMetric exportedMetric = new ExportedMetric.Builder()
                 .withName("processors")
-                .withTimestamp(Instant.EPOCH.plusSeconds(10).getEpochSecond())
-                .withValue(1D)
+                .withTimestamp(EPOCH_SECONDS_PLUS_10_SECS)
+                .withValue(METRIC_VALUE)
                 .build();
 
         // When
@@ -36,8 +35,8 @@ public class ProcessorsProcessorTest {
         // Then
         assertEquals(SYSTEM_METRICS_PREFIX + "processors", processedMetric.getName());
         assertEquals(MetricType.GAUGE, processedMetric.getMetricType());
-        assertEquals(Double.valueOf(1D), processedMetric.getValue());
-        assertEquals(Instant.EPOCH.plusSeconds(10).getEpochSecond(), processedMetric.getTimestamp());
+        assertEquals(Double.valueOf(METRIC_VALUE), processedMetric.getValue());
+        assertEquals(EPOCH_SECONDS_PLUS_10_SECS, processedMetric.getTimestamp());
         assertFalse(processedMetric.getAggregations().isPresent());
         assertFalse(processedMetric.getTags().isPresent());
         assertFalse(processedMetric.getAggregationDetails().isPresent());

--- a/src/test/java/com/statful/client/framework/springboot/processor/processors/system/SystemLoadProcessorTest.java
+++ b/src/test/java/com/statful/client/framework/springboot/processor/processors/system/SystemLoadProcessorTest.java
@@ -5,16 +5,15 @@ import com.statful.client.domain.api.AggregationFrequency;
 import com.statful.client.framework.springboot.common.ExportedMetric;
 import com.statful.client.framework.springboot.common.MetricType;
 import com.statful.client.framework.springboot.common.ProcessedMetric;
+import com.statful.client.framework.springboot.processor.AbstractProcessorTest;
 import org.junit.Before;
 import org.junit.Test;
-
-import java.time.Instant;
 
 import static com.statful.client.framework.springboot.processor.MetricProcessor.SYSTEM_METRICS_PREFIX;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 
-public class SystemLoadProcessorTest {
+public class SystemLoadProcessorTest extends AbstractProcessorTest {
 
     private SystemLoadProcessor subject;
 
@@ -28,8 +27,8 @@ public class SystemLoadProcessorTest {
         // Given
         ExportedMetric exportedMetric = new ExportedMetric.Builder()
                 .withName("systemload.average")
-                .withTimestamp(Instant.EPOCH.plusSeconds(10).getEpochSecond())
-                .withValue(1D)
+                .withTimestamp(EPOCH_SECONDS_PLUS_10_SECS)
+                .withValue(METRIC_VALUE)
                 .build();
 
         // When
@@ -38,8 +37,8 @@ public class SystemLoadProcessorTest {
         // Then
         assertEquals(SYSTEM_METRICS_PREFIX + "systemload", processedMetric.getName());
         assertEquals(MetricType.GAUGE, processedMetric.getMetricType());
-        assertEquals(Double.valueOf(1D), processedMetric.getValue());
-        assertEquals(Instant.EPOCH.plusSeconds(10).getEpochSecond(), processedMetric.getTimestamp());
+        assertEquals(Double.valueOf(METRIC_VALUE), processedMetric.getValue());
+        assertEquals(EPOCH_SECONDS_PLUS_10_SECS, processedMetric.getTimestamp());
         assertFalse(processedMetric.getTags().isPresent());
         assertFalse(processedMetric.getAggregations().isPresent());
         assertEquals(Aggregation.AVG, processedMetric.getAggregationDetails().get().getAggregation());

--- a/src/test/java/com/statful/client/framework/springboot/processor/processors/system/SystemLoadProcessorTest.java
+++ b/src/test/java/com/statful/client/framework/springboot/processor/processors/system/SystemLoadProcessorTest.java
@@ -9,7 +9,6 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.time.Instant;
-import java.util.Date;
 
 import static com.statful.client.framework.springboot.processor.MetricProcessor.SYSTEM_METRICS_PREFIX;
 import static org.junit.Assert.assertEquals;
@@ -29,7 +28,7 @@ public class SystemLoadProcessorTest {
         // Given
         ExportedMetric exportedMetric = new ExportedMetric.Builder()
                 .withName("systemload.average")
-                .withTimestamp(Date.from(Instant.EPOCH))
+                .withTimestamp(Instant.EPOCH.plusSeconds(10).getEpochSecond())
                 .withValue(1D)
                 .build();
 
@@ -40,7 +39,7 @@ public class SystemLoadProcessorTest {
         assertEquals(SYSTEM_METRICS_PREFIX + "systemload", processedMetric.getName());
         assertEquals(MetricType.GAUGE, processedMetric.getMetricType());
         assertEquals(Double.valueOf(1D), processedMetric.getValue());
-        assertEquals(Instant.EPOCH.toEpochMilli(), processedMetric.getTimestamp());
+        assertEquals(Instant.EPOCH.plusSeconds(10).getEpochSecond(), processedMetric.getTimestamp());
         assertFalse(processedMetric.getTags().isPresent());
         assertFalse(processedMetric.getAggregations().isPresent());
         assertEquals(Aggregation.AVG, processedMetric.getAggregationDetails().get().getAggregation());

--- a/src/test/java/com/statful/client/framework/springboot/processor/processors/system/ThreadsProcessorTest.java
+++ b/src/test/java/com/statful/client/framework/springboot/processor/processors/system/ThreadsProcessorTest.java
@@ -7,7 +7,6 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.time.Instant;
-import java.util.Date;
 
 import static com.statful.client.framework.springboot.processor.MetricProcessor.SYSTEM_METRICS_PREFIX;
 import static org.junit.Assert.assertEquals;
@@ -27,7 +26,7 @@ public class ThreadsProcessorTest {
         // Given
         ExportedMetric exportedMetric = new ExportedMetric.Builder()
                 .withName("threads")
-                .withTimestamp(Date.from(Instant.EPOCH))
+                .withTimestamp(Instant.EPOCH.plusSeconds(10).getEpochSecond())
                 .withValue(1D)
                 .build();
 
@@ -38,7 +37,7 @@ public class ThreadsProcessorTest {
         assertEquals(SYSTEM_METRICS_PREFIX + "threads", processedMetric.getName());
         assertEquals(MetricType.GAUGE, processedMetric.getMetricType());
         assertEquals(Double.valueOf(1D), processedMetric.getValue());
-        assertEquals(Instant.EPOCH.toEpochMilli(), processedMetric.getTimestamp());
+        assertEquals(Instant.EPOCH.plusSeconds(10).getEpochSecond(), processedMetric.getTimestamp());
         assertEquals("total", processedMetric.getTags().get().getTagValue("type"));
         assertFalse(processedMetric.getAggregations().isPresent());
         assertFalse(processedMetric.getAggregationDetails().isPresent());
@@ -49,7 +48,7 @@ public class ThreadsProcessorTest {
         // Given
         ExportedMetric exportedMetric = new ExportedMetric.Builder()
                 .withName("threads.peak")
-                .withTimestamp(Date.from(Instant.EPOCH))
+                .withTimestamp(Instant.EPOCH.plusSeconds(10).getEpochSecond())
                 .withValue(1D)
                 .build();
 
@@ -60,7 +59,7 @@ public class ThreadsProcessorTest {
         assertEquals(SYSTEM_METRICS_PREFIX + "threads", processedMetric.getName());
         assertEquals(MetricType.GAUGE, processedMetric.getMetricType());
         assertEquals(Double.valueOf(1D), processedMetric.getValue());
-        assertEquals(Instant.EPOCH.toEpochMilli(), processedMetric.getTimestamp());
+        assertEquals(Instant.EPOCH.plusSeconds(10).getEpochSecond(), processedMetric.getTimestamp());
         assertEquals("peak", processedMetric.getTags().get().getTagValue("type"));
         assertFalse(processedMetric.getAggregations().isPresent());
         assertFalse(processedMetric.getAggregationDetails().isPresent());

--- a/src/test/java/com/statful/client/framework/springboot/processor/processors/system/ThreadsProcessorTest.java
+++ b/src/test/java/com/statful/client/framework/springboot/processor/processors/system/ThreadsProcessorTest.java
@@ -3,16 +3,15 @@ package com.statful.client.framework.springboot.processor.processors.system;
 import com.statful.client.framework.springboot.common.ExportedMetric;
 import com.statful.client.framework.springboot.common.MetricType;
 import com.statful.client.framework.springboot.common.ProcessedMetric;
+import com.statful.client.framework.springboot.processor.AbstractProcessorTest;
 import org.junit.Before;
 import org.junit.Test;
-
-import java.time.Instant;
 
 import static com.statful.client.framework.springboot.processor.MetricProcessor.SYSTEM_METRICS_PREFIX;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 
-public class ThreadsProcessorTest {
+public class ThreadsProcessorTest extends AbstractProcessorTest {
 
     private ThreadsProcessor subject;
 
@@ -26,8 +25,8 @@ public class ThreadsProcessorTest {
         // Given
         ExportedMetric exportedMetric = new ExportedMetric.Builder()
                 .withName("threads")
-                .withTimestamp(Instant.EPOCH.plusSeconds(10).getEpochSecond())
-                .withValue(1D)
+                .withTimestamp(EPOCH_SECONDS_PLUS_10_SECS)
+                .withValue(METRIC_VALUE)
                 .build();
 
         // When
@@ -36,8 +35,8 @@ public class ThreadsProcessorTest {
         // Then
         assertEquals(SYSTEM_METRICS_PREFIX + "threads", processedMetric.getName());
         assertEquals(MetricType.GAUGE, processedMetric.getMetricType());
-        assertEquals(Double.valueOf(1D), processedMetric.getValue());
-        assertEquals(Instant.EPOCH.plusSeconds(10).getEpochSecond(), processedMetric.getTimestamp());
+        assertEquals(Double.valueOf(METRIC_VALUE), processedMetric.getValue());
+        assertEquals(EPOCH_SECONDS_PLUS_10_SECS, processedMetric.getTimestamp());
         assertEquals("total", processedMetric.getTags().get().getTagValue("type"));
         assertFalse(processedMetric.getAggregations().isPresent());
         assertFalse(processedMetric.getAggregationDetails().isPresent());
@@ -48,8 +47,8 @@ public class ThreadsProcessorTest {
         // Given
         ExportedMetric exportedMetric = new ExportedMetric.Builder()
                 .withName("threads.peak")
-                .withTimestamp(Instant.EPOCH.plusSeconds(10).getEpochSecond())
-                .withValue(1D)
+                .withTimestamp(EPOCH_SECONDS_PLUS_10_SECS)
+                .withValue(METRIC_VALUE)
                 .build();
 
         // When
@@ -58,8 +57,8 @@ public class ThreadsProcessorTest {
         // Then
         assertEquals(SYSTEM_METRICS_PREFIX + "threads", processedMetric.getName());
         assertEquals(MetricType.GAUGE, processedMetric.getMetricType());
-        assertEquals(Double.valueOf(1D), processedMetric.getValue());
-        assertEquals(Instant.EPOCH.plusSeconds(10).getEpochSecond(), processedMetric.getTimestamp());
+        assertEquals(Double.valueOf(METRIC_VALUE), processedMetric.getValue());
+        assertEquals(EPOCH_SECONDS_PLUS_10_SECS, processedMetric.getTimestamp());
         assertEquals("peak", processedMetric.getTags().get().getTagValue("type"));
         assertFalse(processedMetric.getAggregations().isPresent());
         assertFalse(processedMetric.getAggregationDetails().isPresent());

--- a/src/test/java/com/statful/client/framework/springboot/processor/processors/system/UptimeProcessorTest.java
+++ b/src/test/java/com/statful/client/framework/springboot/processor/processors/system/UptimeProcessorTest.java
@@ -7,7 +7,6 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.time.Instant;
-import java.util.Date;
 
 import static com.statful.client.framework.springboot.processor.MetricProcessor.SYSTEM_METRICS_PREFIX;
 import static org.junit.Assert.assertEquals;
@@ -27,7 +26,7 @@ public class UptimeProcessorTest {
         // Given
         ExportedMetric exportedMetric = new ExportedMetric.Builder()
                 .withName("uptime")
-                .withTimestamp(Date.from(Instant.EPOCH))
+                .withTimestamp(Instant.EPOCH.plusSeconds(10).getEpochSecond())
                 .withValue(1D)
                 .build();
 
@@ -38,7 +37,7 @@ public class UptimeProcessorTest {
         assertEquals(SYSTEM_METRICS_PREFIX + "uptime", processedMetric.getName());
         assertEquals(MetricType.GAUGE, processedMetric.getMetricType());
         assertEquals(Double.valueOf(1D), processedMetric.getValue());
-        assertEquals(Instant.EPOCH.toEpochMilli(), processedMetric.getTimestamp());
+        assertEquals(Instant.EPOCH.plusSeconds(10).getEpochSecond(), processedMetric.getTimestamp());
         assertEquals("vm", processedMetric.getTags().get().getTagValue("type"));
         assertFalse(processedMetric.getAggregations().isPresent());
         assertFalse(processedMetric.getAggregationDetails().isPresent());
@@ -49,7 +48,7 @@ public class UptimeProcessorTest {
         // Given
         ExportedMetric exportedMetric = new ExportedMetric.Builder()
                 .withName("instance.uptime")
-                .withTimestamp(Date.from(Instant.EPOCH))
+                .withTimestamp(Instant.EPOCH.plusSeconds(10).getEpochSecond())
                 .withValue(1D)
                 .build();
 
@@ -60,7 +59,7 @@ public class UptimeProcessorTest {
         assertEquals(SYSTEM_METRICS_PREFIX + "uptime", processedMetric.getName());
         assertEquals(MetricType.GAUGE, processedMetric.getMetricType());
         assertEquals(Double.valueOf(1D), processedMetric.getValue());
-        assertEquals(Instant.EPOCH.toEpochMilli(), processedMetric.getTimestamp());
+        assertEquals(Instant.EPOCH.plusSeconds(10).getEpochSecond(), processedMetric.getTimestamp());
         assertEquals("instance", processedMetric.getTags().get().getTagValue("type"));
         assertFalse(processedMetric.getAggregations().isPresent());
         assertFalse(processedMetric.getAggregationDetails().isPresent());

--- a/src/test/java/com/statful/client/framework/springboot/processor/processors/system/UptimeProcessorTest.java
+++ b/src/test/java/com/statful/client/framework/springboot/processor/processors/system/UptimeProcessorTest.java
@@ -3,16 +3,15 @@ package com.statful.client.framework.springboot.processor.processors.system;
 import com.statful.client.framework.springboot.common.ExportedMetric;
 import com.statful.client.framework.springboot.common.MetricType;
 import com.statful.client.framework.springboot.common.ProcessedMetric;
+import com.statful.client.framework.springboot.processor.AbstractProcessorTest;
 import org.junit.Before;
 import org.junit.Test;
-
-import java.time.Instant;
 
 import static com.statful.client.framework.springboot.processor.MetricProcessor.SYSTEM_METRICS_PREFIX;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 
-public class UptimeProcessorTest {
+public class UptimeProcessorTest extends AbstractProcessorTest {
 
     private UptimeProcessor subject;
 
@@ -26,8 +25,8 @@ public class UptimeProcessorTest {
         // Given
         ExportedMetric exportedMetric = new ExportedMetric.Builder()
                 .withName("uptime")
-                .withTimestamp(Instant.EPOCH.plusSeconds(10).getEpochSecond())
-                .withValue(1D)
+                .withTimestamp(EPOCH_SECONDS_PLUS_10_SECS)
+                .withValue(METRIC_VALUE)
                 .build();
 
         // When
@@ -36,8 +35,8 @@ public class UptimeProcessorTest {
         // Then
         assertEquals(SYSTEM_METRICS_PREFIX + "uptime", processedMetric.getName());
         assertEquals(MetricType.GAUGE, processedMetric.getMetricType());
-        assertEquals(Double.valueOf(1D), processedMetric.getValue());
-        assertEquals(Instant.EPOCH.plusSeconds(10).getEpochSecond(), processedMetric.getTimestamp());
+        assertEquals(Double.valueOf(METRIC_VALUE), processedMetric.getValue());
+        assertEquals(EPOCH_SECONDS_PLUS_10_SECS, processedMetric.getTimestamp());
         assertEquals("vm", processedMetric.getTags().get().getTagValue("type"));
         assertFalse(processedMetric.getAggregations().isPresent());
         assertFalse(processedMetric.getAggregationDetails().isPresent());
@@ -48,8 +47,8 @@ public class UptimeProcessorTest {
         // Given
         ExportedMetric exportedMetric = new ExportedMetric.Builder()
                 .withName("instance.uptime")
-                .withTimestamp(Instant.EPOCH.plusSeconds(10).getEpochSecond())
-                .withValue(1D)
+                .withTimestamp(EPOCH_SECONDS_PLUS_10_SECS)
+                .withValue(METRIC_VALUE)
                 .build();
 
         // When
@@ -58,8 +57,8 @@ public class UptimeProcessorTest {
         // Then
         assertEquals(SYSTEM_METRICS_PREFIX + "uptime", processedMetric.getName());
         assertEquals(MetricType.GAUGE, processedMetric.getMetricType());
-        assertEquals(Double.valueOf(1D), processedMetric.getValue());
-        assertEquals(Instant.EPOCH.plusSeconds(10).getEpochSecond(), processedMetric.getTimestamp());
+        assertEquals(Double.valueOf(METRIC_VALUE), processedMetric.getValue());
+        assertEquals(EPOCH_SECONDS_PLUS_10_SECS, processedMetric.getTimestamp());
         assertEquals("instance", processedMetric.getTags().get().getTagValue("type"));
         assertFalse(processedMetric.getAggregations().isPresent());
         assertFalse(processedMetric.getAggregationDetails().isPresent());

--- a/src/test/java/com/statful/client/framework/springboot/processor/processors/tomcat/HttpSessionsProcessorTest.java
+++ b/src/test/java/com/statful/client/framework/springboot/processor/processors/tomcat/HttpSessionsProcessorTest.java
@@ -3,16 +3,15 @@ package com.statful.client.framework.springboot.processor.processors.tomcat;
 import com.statful.client.framework.springboot.common.ExportedMetric;
 import com.statful.client.framework.springboot.common.MetricType;
 import com.statful.client.framework.springboot.common.ProcessedMetric;
+import com.statful.client.framework.springboot.processor.AbstractProcessorTest;
 import org.junit.Before;
 import org.junit.Test;
-
-import java.time.Instant;
 
 import static com.statful.client.framework.springboot.processor.MetricProcessor.TOMCAT_METRICS_PREFIX;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 
-public class HttpSessionsProcessorTest {
+public class HttpSessionsProcessorTest extends AbstractProcessorTest {
 
     private HttpSessionsProcessor subject;
 
@@ -26,8 +25,8 @@ public class HttpSessionsProcessorTest {
         // Given
         ExportedMetric exportedMetric = new ExportedMetric.Builder()
                 .withName("httpsessions.max")
-                .withTimestamp(Instant.EPOCH.plusSeconds(10).getEpochSecond())
-                .withValue(1D)
+                .withTimestamp(EPOCH_SECONDS_PLUS_10_SECS)
+                .withValue(METRIC_VALUE)
                 .build();
 
         // When
@@ -36,8 +35,8 @@ public class HttpSessionsProcessorTest {
         // Then
         assertEquals(TOMCAT_METRICS_PREFIX + "httpsessions", processedMetric.getName());
         assertEquals(MetricType.GAUGE, processedMetric.getMetricType());
-        assertEquals(Double.valueOf(1D), processedMetric.getValue());
-        assertEquals(Instant.EPOCH.plusSeconds(10).getEpochSecond(), processedMetric.getTimestamp());
+        assertEquals(Double.valueOf(METRIC_VALUE), processedMetric.getValue());
+        assertEquals(EPOCH_SECONDS_PLUS_10_SECS, processedMetric.getTimestamp());
         assertEquals("max", processedMetric.getTags().get().getTagValue("type"));
         assertFalse(processedMetric.getAggregations().isPresent());
         assertFalse(processedMetric.getAggregationDetails().isPresent());

--- a/src/test/java/com/statful/client/framework/springboot/processor/processors/tomcat/HttpSessionsProcessorTest.java
+++ b/src/test/java/com/statful/client/framework/springboot/processor/processors/tomcat/HttpSessionsProcessorTest.java
@@ -7,7 +7,6 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.time.Instant;
-import java.util.Date;
 
 import static com.statful.client.framework.springboot.processor.MetricProcessor.TOMCAT_METRICS_PREFIX;
 import static org.junit.Assert.assertEquals;
@@ -27,7 +26,7 @@ public class HttpSessionsProcessorTest {
         // Given
         ExportedMetric exportedMetric = new ExportedMetric.Builder()
                 .withName("httpsessions.max")
-                .withTimestamp(Date.from(Instant.EPOCH))
+                .withTimestamp(Instant.EPOCH.plusSeconds(10).getEpochSecond())
                 .withValue(1D)
                 .build();
 
@@ -38,7 +37,7 @@ public class HttpSessionsProcessorTest {
         assertEquals(TOMCAT_METRICS_PREFIX + "httpsessions", processedMetric.getName());
         assertEquals(MetricType.GAUGE, processedMetric.getMetricType());
         assertEquals(Double.valueOf(1D), processedMetric.getValue());
-        assertEquals(Instant.EPOCH.toEpochMilli(), processedMetric.getTimestamp());
+        assertEquals(Instant.EPOCH.plusSeconds(10).getEpochSecond(), processedMetric.getTimestamp());
         assertEquals("max", processedMetric.getTags().get().getTagValue("type"));
         assertFalse(processedMetric.getAggregations().isPresent());
         assertFalse(processedMetric.getAggregationDetails().isPresent());


### PR DESCRIPTION
 Timestamps should be epoch in seconds.

 Also change the ExportedMetric fields value and timestamp to be their final types in order to delegate conversion to the entry point instead of doing it across all processors.